### PR TITLE
Release 133

### DIFF
--- a/pallets/fund-admin/src/mock.rs
+++ b/pallets/fund-admin/src/mock.rs
@@ -78,7 +78,6 @@ parameter_types! {
 	pub const MaxJobEligiblesByProject:u32 = 1000;
 	pub const MaxRevenuesByProject:u32 = 1000;
 	pub const MaxTransactionsPerRevenue:u32 = 500;
-
 }
 
 impl pallet_fund_admin::Config for Test {
@@ -108,7 +107,6 @@ impl pallet_fund_admin::Config for Test {
 	type MaxJobEligiblesByProject = MaxJobEligiblesByProject;       
 	type MaxRevenuesByProject = MaxRevenuesByProject;        
 	type MaxTransactionsPerRevenue = MaxTransactionsPerRevenue;  
-
 }
 
 

--- a/pallets/fund-admin/src/types.rs
+++ b/pallets/fund-admin/src/types.rs
@@ -30,7 +30,7 @@ pub type DrawdownNumber = u32;
 
 // Budget expenditures
 pub type ExpenditureId = [u8; 32];
-pub type ExpenditureAmount = u64;
+pub type ExpenditureAmount = Amount;
 pub type NAICSCode = BoundedVec<u8, ConstU32<400>>;
 pub type JobsMultiplier = u32;
 pub type InflationRate = u32;
@@ -38,12 +38,12 @@ pub type InflationRate = u32;
 // Miscellaneous
 pub type CreatedDate = u64;
 pub type CloseDate = u64;
-pub type TotalAmount = u64;
+pub type TotalAmount = Amount;
 
 // Revenues
-pub type RevenueAmount = u128;
+pub type RevenueAmount = Amount;
 pub type JobEligibleId = [u8; 32];
-pub type JobEligibleAmount = u128;
+pub type JobEligibleAmount = Amount;
 pub type RevenueId = [u8; 32];
 pub type RevenueNumber = u32;
 pub type RevenueTransactionId = [u8; 32];
@@ -71,7 +71,6 @@ pub struct ProjectData<T: Config> {
 	pub construction_loan_drawdown_status: Option<DrawdownStatus>,
 	pub developer_equity_drawdown_status: Option<DrawdownStatus>,
     pub revenue_status: Option<RevenueStatus>,
-
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebugNoBound, MaxEncodedLen, TypeInfo, Copy)]
@@ -141,7 +140,8 @@ pub struct DrawdownData<T: Config> {
     pub drawdown_type: DrawdownType,
     pub total_amount: TotalAmount,
     pub status: DrawdownStatus,
-    pub documents: Option<Documents<T>>,
+    pub bulkupload_documents: Option<Documents<T>>,
+    pub bank_documents: Option<Documents<T>>,
     pub description: Option<FieldDescription>,
     pub feedback: Option<FieldDescription>,
     pub created_date: CreatedDate,
@@ -167,6 +167,7 @@ pub enum DrawdownStatus {
     Submitted,
     Approved,
     Rejected,
+    Confirmed,
 }
 
 impl Default for DrawdownStatus {
@@ -197,6 +198,7 @@ pub enum TransactionStatus {
     Submitted,
     Approved,
     Rejected,
+    Confirmed
 }
 
 impl Default for TransactionStatus {

--- a/pallets/gated-marketplace/README.md
+++ b/pallets/gated-marketplace/README.md
@@ -110,15 +110,15 @@ This module allows to:
 ### Getters
 |Name| Type |
 |--|--|
-|`marketplaces`| storage map|
-|`applications`| storage map|
-|`applications_by_account`|double storage map|
-|`applicants_by_marketplace`|double storage map|
-|`custodians`|double storage map|
-|`offers_info` |storage map|
-|`offers_by_item`|double storage map|
-|`offers_by_account`|storage map|
-|`offers_by_marketplace`|storage map|
+|`marketplaces`| storagemap|
+|`applications`| storagemap|
+|`applications_by_account`|double storagemap|
+|`applicants_by_marketplace`|double storagemap|
+|`custodians`|double storagemap|
+|`offers_info` |storagemap|
+|`offers_by_item`|double storagemap|
+|`offers_by_account`|storagemap|
+|`offers_by_marketplace`|storagemap|
 
 
 ## Usage

--- a/pallets/gated-marketplace/src/functions.rs
+++ b/pallets/gated-marketplace/src/functions.rs
@@ -788,7 +788,7 @@ impl<T: Config> Pallet<T> {
                 buy_offer_ids.try_push(offer_id).map_err(|_| Error::<T>::LimitExceeded)?;
             }
         }
-        //ensure we already took the entry from the storage map, so we can insert it again.
+        //ensure we already took the entry from the storagemap, so we can insert it again.
         ensure!(!<OffersByItem<T>>::contains_key(collection_id, item_id), Error::<T>::OfferNotFound);
         <OffersByItem<T>>::insert(collection_id, item_id, buy_offer_ids);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -106,7 +106,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 132,
+	spec_version: 133,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -576,7 +576,6 @@ parameter_types! {
 	pub const MaxJobEligiblesByProject:u32 = 1000;
 	pub const MaxRevenuesByProject:u32 = 1000;
 	pub const MaxTransactionsPerRevenue:u32 = 500;
-
 }
 
 impl pallet_fund_admin::Config for Runtime {
@@ -609,7 +608,6 @@ impl pallet_fund_admin::Config for Runtime {
 	type MaxJobEligiblesByProject = MaxJobEligiblesByProject;
 	type MaxRevenuesByProject = MaxRevenuesByProject;
 	type MaxTransactionsPerRevenue = MaxTransactionsPerRevenue;
-
 
 }
 


### PR DESCRIPTION
* Update internal documentation

* Add a helper function that will handle the creation, updating & deletion od the revenue transactions. Fix typos.

* Update revenue amount to use u128n instead u64 data type

* implememnt an enum to track the revenue transaction status

* set the default value for the revenue status to draft

* Add a helper private function to create revenue transactions

* Add a helper private function to update revenue transactions. Delete helper function: is_amount_valid?, is no longer required since this project does not use real balances.

* Add a helper function to delete revenues transaction. Update/add some pallet errors from drawdown helper functions.

* Finish the logic needed for the helper function: do_execute_revenue_transactions

* Implement defult value for RevenueStatus

* Remove documents field from RevenueData structure

* Update traits for RevenueData due to the documents fields deletion

* Update project creation flow to allow revenues creation. Add helper functions to handle the revenue initialization & creation.

* Modify ProjectData<T> structure in order to track the last status of the current revenue

* Add a helper function to track in which status is the last revenue created

* Create a helper function to handle the revenue submission. odify one helper function used in the drawdows flow. I updated the validation function to check where a transaction is editable.

* Add an extrinsic to handle the revenue submission. It considers both flows, save it as draft or submit the revenue.

* Modify do_submit_drawdown helper function, I removed the feedback at drawdown level after a builder re-submits a rejected bulkupload drawdown

* I removed the feedback at drawdown level after a builder re-submits a rejected bulkupload drawdown. Create a helper function to handle the revenue approval.

* Add a new extrinsic to handle the revenue approval

* te a helper function to handle the revenue rejection

* Add new extrinsic to handle the revenue rejection

* Add a new drawdows status: Confirmed

* Add a new transaction status: Confirmed

* Update amount data type to u64

* Update validations for the new drawdown status, "Confirmed"

* Delete unreachable validations when rejecting a bulkupload drawdown. Update validations for individual transactions in the EB5 drawdown flow.

* Update  some validations for the revenue transactions flow.

* Rename "documents" field in the DrawdownData structure to "bulkupload_documents".  Remove one extra validation in the do_up_bulk_upload helper function.  Replace the pallet error with a more readable name.

* Add a new field into the DrawdownData structure: "bank_documents", in order to track when an administrator has uploaded the documents provided by the bank

* Delete comments: Unused extrinsic to handle job eligibles

* Add initial flow for the bank confirming documents flow. This flow uses CUDActions because it was designed based on the error recovery requirement.

* The helper function "do_bank_confirming_documents" could be difficult to read. I modularized each flow into individual helper private functions. Fix #282

* Update internal documentation

* Update the kill storage extrinsic in order to delete the new added storage maps for the revenues flow.

* Fix #286. Update comments. Rearrange internal pallet distribution.  Missing events were added.

* Fix mistype

Co-authored-by: Erick Casanova <desneruda@gmail.com>