### PR TITLE
Remove a rigorous validation during a drawdown approval

### DIFF
--- a/pallets/fund-admin/src/functions.rs
+++ b/pallets/fund-admin/src/functions.rs
@@ -908,14 +908,11 @@ impl<T: Config> Pallet<T> {
         project_id: ProjectId,
         drawdown_id: DrawdownId,
     ) -> DispatchResult {
-        //TODO: update permissions
+        // TODO: update permissions
         // Ensure admin permissions
         Self::is_authorized(admin.clone(), &Self::get_global_scope(), ProxyPermission::Expenditures)?;
 
-        // Ensure drawdown is editable & ensure drawdown exists
-        Self::is_drawdown_editable(drawdown_id)?;
-
-        // Get drawdown data
+        // Get drawdown data & ensure drawdown exists
         let drawdown_data = DrawdownsInfo::<T>::get(drawdown_id).ok_or(Error::<T>::DrawdownNotFound)?;
 
         // Ensure drawdown has transactions


### PR DESCRIPTION
Hotfix to remove a validation when an administrator is approving an EB5 drawdown.