### PR TITLE
Release 136

### DIFF
--- a/pallets/fund-admin/src/functions.rs
+++ b/pallets/fund-admin/src/functions.rs
@@ -976,9 +976,6 @@ impl<T: Config> Pallet<T> {
         // Ensure admin permissions
         Self::is_authorized(admin.clone(), None, ProxyPermission::RejectDrawdown)?;
 
-        // Ensure drawdown is editable & ensure drawdown exists
-        Self::is_drawdown_editable(drawdown_id)?;
-
         // Get drawdown data
         let drawdown_data = DrawdownsInfo::<T>::get(drawdown_id).ok_or(Error::<T>::DrawdownNotFound)?;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -106,7 +106,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 135,
+	spec_version: 136,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Remove rigorous validation while rejecting a drawdown. (#308)