### PR TITLE
Bitcoin vaults: Proof of reserve functionality

### DIFF
--- a/pallets/bitcoin-vaults/README.md
+++ b/pallets/bitcoin-vaults/README.md
@@ -369,6 +369,10 @@ ProposalStored([u8;32],T::AccountId),
 ProposalRemoved([u8;32],T::AccountId),
 /// A proposal tx has been inserted by an OCW
 ProposalTxIdStored([u8;32])
+/// A proof of reserve was stored for the vault
+ProofOfReserveStored([u8; 32]),
+/// A psbt was stored for the vaults Proof of reserve
+ProofPSBTStored([u8; 32]),
 ```
 
 ## Errors
@@ -423,6 +427,8 @@ NotEnoughSignatures,
 InvalidProposal,
 /// This vault cant take proposals due to structural failures
 InvalidVault,
+/// The proof of reserve was not found
+ProofNotFound
 ```
 
 ## Assumptions
@@ -430,7 +436,7 @@ InvalidVault,
 Below are assumptions that must be held when using this module.  If any of
 them are violated, the behavior of this module is undefined.
 
-- The pallet relies on the remote endpoint `bdk-services` to generate descriptors, proposals, and next adressesss.
+- The pallet relies on the remote endpoint `bdk-services` to generate descriptors, proposals, and next adressess.
 
 
 License: Apache-2.0

--- a/pallets/bitcoin-vaults/src/functions.rs
+++ b/pallets/bitcoin-vaults/src/functions.rs
@@ -1,686 +1,812 @@
 use super::*;
+use crate::types::*;
 use frame_support::pallet_prelude::*;
-use frame_support::{sp_io::hashing::blake2_256};
-use frame_system::offchain::{Signer, SendUnsignedTransaction};
-use sp_runtime::sp_std::str;
-use sp_runtime::sp_std::vec::Vec;
-use sp_runtime::traits::BlockNumberProvider;
-use sp_runtime::{
-    offchain::{
-        http,
-        Duration,
-    },
-};
+use frame_support::sp_io::hashing::blake2_256;
+use frame_system::offchain::{SendUnsignedTransaction, Signer};
 use lite_json::json::{JsonValue, NumberValue};
 use lite_json::parse_json;
 use lite_json::Serialize as jsonSerialize;
-use crate::types::*;
+use sp_runtime::offchain::{http, Duration};
+use sp_runtime::sp_std::str;
+use sp_runtime::sp_std::vec::Vec;
+use sp_runtime::traits::BlockNumberProvider;
 
 impl<T: Config> Pallet<T> {
-    /*---- Extrinsics  ----*/
-    /// Use with caution
-    pub fn do_remove_xpub(who: T::AccountId) -> DispatchResult {
-        let old_hash = <XpubsByOwner<T>>::take(who.clone()).ok_or(Error::<T>::XPubNotFound)?;
-        <Xpubs<T>>::remove(old_hash);
-        Self::deposit_event(Event::XPubRemoved(who));
-        Ok(())
-    }
+	/*---- Extrinsics  ----*/
+	/// Use with caution
+	pub fn do_remove_xpub(who: T::AccountId) -> DispatchResult {
+		let old_hash = <XpubsByOwner<T>>::take(who.clone()).ok_or(Error::<T>::XPubNotFound)?;
+		<Xpubs<T>>::remove(old_hash);
+		Self::deposit_event(Event::XPubRemoved(who));
+		Ok(())
+	}
 
-    pub fn do_insert_vault(vault: Vault<T>) -> DispatchResult {
-        //TODO vault_id exist?
-        // generate vault id
-        ensure!(vault.signers_are_unique(), Error::<T>::DuplicateVaultMembers);
-        let vault_id = vault.using_encoded(blake2_256);
-        // build a vector containing owner + signers
-        let vault_members = vault.cosigners.to_vec();
-        // iterate over that vector and add the vault id to the list of each user (signer)
-        vault_members.clone().into_iter().try_for_each(|acc| {
-            // check if all users have an xpub
-            if !<XpubsByOwner<T>>::contains_key(acc.clone()) {
-                return Err(Error::<T>::XPubNotFound);
-            }
-            <VaultsBySigner<T>>::try_mutate(acc, |vault_vec| {
-                vault_vec.try_push(vault_id.clone())
-            })
-            .map_err(|_| Error::<T>::SignerVaultLimit)
-        })?;
+	pub fn do_insert_vault(vault: Vault<T>) -> DispatchResult {
+		//TODO vault_id exist?
+		// generate vault id
+		ensure!(vault.signers_are_unique(), Error::<T>::DuplicateVaultMembers);
+		let vault_id = vault.using_encoded(blake2_256);
+		// build a vector containing owner + signers
+		let vault_members = vault.cosigners.to_vec();
+		// iterate over that vector and add the vault id to the list of each user (signer)
+		vault_members.clone().into_iter().try_for_each(|acc| {
+			// check if all users have an xpub
+			if !<XpubsByOwner<T>>::contains_key(acc.clone()) {
+				return Err(Error::<T>::XPubNotFound);
+			}
+			<VaultsBySigner<T>>::try_mutate(acc, |vault_vec| vault_vec.try_push(vault_id.clone()))
+				.map_err(|_| Error::<T>::SignerVaultLimit)
+		})?;
 
-        // insert owner in case it isn't on the cosigners list
-        if !vault_members.contains(&vault.owner) {
-            <VaultsBySigner<T>>::try_mutate(&vault.owner, |vault_vec| {
-                vault_vec.try_push(vault_id.clone())
-            })
-            .map_err(|_| Error::<T>::SignerVaultLimit)?;
-        }
-        <Vaults<T>>::insert(vault_id.clone(), vault.clone());
+		// insert owner in case it isn't on the cosigners list
+		if !vault_members.contains(&vault.owner) {
+			<VaultsBySigner<T>>::try_mutate(&vault.owner, |vault_vec| {
+				vault_vec.try_push(vault_id.clone())
+			})
+			.map_err(|_| Error::<T>::SignerVaultLimit)?;
+		}
+		<Vaults<T>>::insert(vault_id.clone(), vault.clone());
 
-        Self::deposit_event(Event::VaultStored(vault_id, vault.owner));
-        Ok(())
-    }
+		Self::deposit_event(Event::VaultStored(vault_id, vault.owner));
+		Ok(())
+	}
 
-    pub fn do_remove_vault(owner: T::AccountId, vault_id: [u8;32]) -> DispatchResult{
-        // This removes the vault while retrieving its values
-        let vault =  <Vaults<T>>::take(vault_id).ok_or(Error::<T>::VaultNotFound)?;
-        ensure!(vault.owner.eq(&owner), Error::<T>::VaultOwnerPermissionsNeeded);
-        let vault_members = vault.get_vault_members();
-        // Removes the vault from user->vault vector
-        vault_members.iter().try_for_each(|signer|{
-            <VaultsBySigner<T>>::try_mutate::<_,(),DispatchError,_>(signer, |vault_list|{
-                let vault_index = vault_list.iter().position(|v| *v==vault_id).ok_or(Error::<T>::VaultNotFound)?;
-                vault_list.remove(vault_index);
-                Ok(())
-            })
-        })?;
-        // Removes all vault proposals
-        let vault_proposals = <ProposalsByVault<T>>::get(vault_id);
-        vault_proposals.iter().try_for_each(|proposal_id|{
-            Self::do_remove_proposal(*proposal_id)
-        })?;
-        Self::deposit_event(Event::VaultRemoved(vault_id, vault.owner));
-        Ok(())
-    }
+	pub fn do_remove_vault(owner: T::AccountId, vault_id: [u8; 32]) -> DispatchResult {
+		// This removes the vault while retrieving its values
+		let vault = <Vaults<T>>::take(vault_id).ok_or(Error::<T>::VaultNotFound)?;
+		ensure!(vault.owner.eq(&owner), Error::<T>::VaultOwnerPermissionsNeeded);
+		let vault_members = vault.get_vault_members();
+		// Removes the vault from user->vault vector
+		vault_members.iter().try_for_each(|signer| {
+			<VaultsBySigner<T>>::try_mutate::<_, (), DispatchError, _>(signer, |vault_list| {
+				let vault_index = vault_list
+					.iter()
+					.position(|v| *v == vault_id)
+					.ok_or(Error::<T>::VaultNotFound)?;
+				vault_list.remove(vault_index);
+				Ok(())
+			})
+		})?;
+		// Removes all vault proposals
+		let vault_proposals = <ProposalsByVault<T>>::get(vault_id);
+		vault_proposals
+			.iter()
+			.try_for_each(|proposal_id| Self::do_remove_proposal(*proposal_id))?;
+		// Removes vault proof
+		Self::do_remove_proof(vault_id);
+		Self::deposit_event(Event::VaultRemoved(vault_id, vault.owner));
+		Ok(())
+	}
 
-    pub fn do_remove_proposal(proposal_id: [u8;32]) -> DispatchResult{
-        let proposal = <Proposals<T>>::take(proposal_id).ok_or(Error::<T>::ProposalNotFound)?;
-        <ProposalsByVault<T>>::try_mutate::<_,_,DispatchError,_>(proposal.vault_id, |proposal_list|{
-            let proposal_index= proposal_list.iter().position(|p| p==&proposal_id).ok_or(Error::<T>::ProposalNotFound)?;
-            proposal_list.remove(proposal_index);
-            Ok(())
-        })?;
-        Self::deposit_event(Event::ProposalRemoved(proposal_id, proposal.proposer));
-        Ok(())
-    }
+	pub fn do_remove_proposal(proposal_id: [u8; 32]) -> DispatchResult {
+		let proposal = <Proposals<T>>::take(proposal_id).ok_or(Error::<T>::ProposalNotFound)?;
+		<ProposalsByVault<T>>::try_mutate::<_, _, DispatchError, _>(
+			proposal.vault_id,
+			|proposal_list| {
+				let proposal_index = proposal_list
+					.iter()
+					.position(|p| p == &proposal_id)
+					.ok_or(Error::<T>::ProposalNotFound)?;
+				proposal_list.remove(proposal_index);
+				Ok(())
+			},
+		)?;
+		Self::deposit_event(Event::ProposalRemoved(proposal_id, proposal.proposer));
+		Ok(())
+	}
 
-    pub fn do_propose(proposal: Proposal<T>)->DispatchResult{
-        Self::vault_comprobations(proposal.vault_id, &proposal.proposer)?;
-        let proposal_id = proposal.using_encoded(blake2_256);
-        ensure!(!<Proposals<T>>::contains_key(&proposal_id), Error::<T>::AlreadyProposed);
-        <Proposals<T>>::insert(proposal_id, proposal.clone());
-        <ProposalsByVault<T>>::try_mutate(proposal.vault_id,|proposals|{
-            proposals.try_push(proposal_id)
-        }).map_err(|_| Error::<T>::ExceedMaxProposalsPerVault)?;
+	pub fn do_propose(proposal: Proposal<T>) -> DispatchResult {
+		Self::vault_comprobations(proposal.vault_id, &proposal.proposer)?;
+		let proposal_id = proposal.using_encoded(blake2_256);
+		ensure!(!<Proposals<T>>::contains_key(&proposal_id), Error::<T>::AlreadyProposed);
+		<Proposals<T>>::insert(proposal_id, proposal.clone());
+		<ProposalsByVault<T>>::try_mutate(proposal.vault_id, |proposals| {
+			proposals.try_push(proposal_id)
+		})
+		.map_err(|_| Error::<T>::ExceedMaxProposalsPerVault)?;
 
-        Self::deposit_event(Event::ProposalStored(proposal_id, proposal.proposer));
-        Ok(())
-    }
+		Self::deposit_event(Event::ProposalStored(proposal_id, proposal.proposer));
+		Ok(())
+	}
 
-    pub fn do_save_psbt(signer: T::AccountId, proposal_id: [u8;32], signature_payload: BoundedVec<u8, T::PSBTMaxLen>) -> DispatchResult{
-        // validations: proposal exists, signer is member of vault, proposal is pending,
-        let vault_id = <Proposals<T>>::get(proposal_id).ok_or(Error::<T>::ProposalNotFound)?.vault_id;
-        let vault =  <Vaults<T>>::get(vault_id).ok_or(Error::<T>::VaultNotFound)?;
-        ensure!(vault.is_vault_member(&signer), Error::<T>::SignerPermissionsNeeded);
-        let signature = ProposalSignatures{
-            signer: signer.clone(),
-            signature: signature_payload,
-        };
-        <Proposals<T>>::try_mutate::<_,(),DispatchError,_>(proposal_id, |proposal| {
-            proposal.as_ref().ok_or(Error::<T>::ProposalNotFound)?;
-            if let Some(p) = proposal {
-                let signed_already = p.signed_psbts.iter().find(|&signature|{ signature.signer ==signer }).is_some();
-                ensure!(!signed_already, Error::<T>::AlreadySigned);
-                p.signed_psbts.try_push(signature).map_err(|_| Error::<T>::ExceedMaxCosignersPerVault)?;
+	pub fn do_save_psbt(
+		signer: T::AccountId,
+		proposal_id: [u8; 32],
+		signature_payload: BoundedVec<u8, T::PSBTMaxLen>,
+	) -> DispatchResult {
+		// validations: proposal exists, signer is member of vault, proposal is pending,
+		let vault_id =
+			<Proposals<T>>::get(proposal_id).ok_or(Error::<T>::ProposalNotFound)?.vault_id;
+		let vault = <Vaults<T>>::get(vault_id).ok_or(Error::<T>::VaultNotFound)?;
+		ensure!(vault.is_vault_member(&signer), Error::<T>::SignerPermissionsNeeded);
+		let signature = ProposalSignatures { signer: signer.clone(), signature: signature_payload };
+		<Proposals<T>>::try_mutate::<_, (), DispatchError, _>(proposal_id, |proposal| {
+			proposal.as_ref().ok_or(Error::<T>::ProposalNotFound)?;
+			if let Some(p) = proposal {
+				let signed_already =
+					p.signed_psbts.iter().find(|&signature| signature.signer == signer).is_some();
+				ensure!(!signed_already, Error::<T>::AlreadySigned);
+				p.signed_psbts
+					.try_push(signature)
+					.map_err(|_| Error::<T>::ExceedMaxCosignersPerVault)?;
 				if p.signed_psbts.len() as u32 == vault.threshold {
 					p.status.clone_from(&ProposalStatus::ReadyToFinalize(false));
 				}
-            }
-            Ok(())
-        })?;
+			}
+			Ok(())
+		})?;
 
-        Self::deposit_event(Event::ProposalSigned(proposal_id, signer));
-        Ok(())
-    }
+		Self::deposit_event(Event::ProposalSigned(proposal_id, signer));
+		Ok(())
+	}
 
-    pub fn do_finalize_psbt(signer: T::AccountId, proposal_id: [u8;32], broadcast: bool) -> DispatchResult{
-        let proposal = <Proposals<T>>::get(proposal_id).ok_or(Error::<T>::ProposalNotFound)?;
-        let vault = <Vaults<T>>::get(proposal.vault_id).ok_or(Error::<T>::VaultNotFound)?;
-        ensure!(proposal.offchain_status.eq(&BDKStatus::Valid), Error::<T>::InvalidProposal );
-        // can be called by any vault signer
-        ensure!(vault.is_vault_member(&signer), Error::<T>::SignerPermissionsNeeded);
-        // if its finalized then fire error "already finalized" or "already broadcasted"
-        ensure!(proposal.status.eq(&ProposalStatus::Pending) || proposal.status.eq(&ProposalStatus::Finalized),
-            Error::<T>::PendingProposalRequired );
-        // signs must be greater or equal than threshold
-        ensure!(proposal.signed_psbts.len() as u32 >= vault.threshold, Error::<T>::NotEnoughSignatures);
-        // set status to: ready to be finalized
-        <Proposals<T>>::try_mutate::<_,(),DispatchError,_>(proposal_id, |proposal|{
-            proposal.as_ref().ok_or( Error::<T>::ProposalNotFound)?;
-            if let Some(p) = proposal{
-                p.status.clone_from(&ProposalStatus::ReadyToFinalize(broadcast) )
-            }
-            Ok(())
-        })?;
+	pub fn do_finalize_psbt(
+		signer: T::AccountId,
+		proposal_id: [u8; 32],
+		broadcast: bool,
+	) -> DispatchResult {
+		let proposal = <Proposals<T>>::get(proposal_id).ok_or(Error::<T>::ProposalNotFound)?;
+		let vault = <Vaults<T>>::get(proposal.vault_id).ok_or(Error::<T>::VaultNotFound)?;
+		ensure!(proposal.offchain_status.eq(&BDKStatus::Valid), Error::<T>::InvalidProposal);
+		// can be called by any vault signer
+		ensure!(vault.is_vault_member(&signer), Error::<T>::SignerPermissionsNeeded);
+		// if its finalized then fire error "already finalized" or "already broadcasted"
+		ensure!(
+			proposal.status.eq(&ProposalStatus::Pending)
+				|| proposal.status.eq(&ProposalStatus::Finalized),
+			Error::<T>::PendingProposalRequired
+		);
+		// signs must be greater or equal than threshold
+		ensure!(
+			proposal.signed_psbts.len() as u32 >= vault.threshold,
+			Error::<T>::NotEnoughSignatures
+		);
+		// set status to: ready to be finalized
+		<Proposals<T>>::try_mutate::<_, (), DispatchError, _>(proposal_id, |proposal| {
+			proposal.as_ref().ok_or(Error::<T>::ProposalNotFound)?;
+			if let Some(p) = proposal {
+				p.status.clone_from(&ProposalStatus::ReadyToFinalize(broadcast))
+			}
+			Ok(())
+		})?;
 
-        Self::deposit_event(Event::ProposalFinalized(proposal_id, signer));
-        Ok(())
-    }
+		Self::deposit_event(Event::ProposalFinalized(proposal_id, signer));
+		Ok(())
+	}
 
-    pub fn do_create_proof(signer: T::AccountId, vault_id: [u8; 32], message: Description<T>,psbt: PSBT<T>) -> DispatchResult {
-        Self::vault_comprobations(vault_id,&signer)?;
+	pub fn do_create_proof(
+		signer: T::AccountId,
+		vault_id: [u8; 32],
+		message: Description<T>,
+		psbt: PSBT<T>,
+	) -> DispatchResult {
+		Self::vault_comprobations(vault_id, &signer)?;
 
-        let new_proof = ProofOfReserve::<T>{
-            status: ProposalStatus::Pending,
-            message: message,
-            psbt: psbt,
-            signed_psbts: BoundedVec::<ProposalSignatures<T>, T::MaxCosignersPerVault>::default()
-        };
-        <ProofOfReserves<T>>::insert(vault_id, new_proof);
-        Ok(())
-    }
+		let new_proof = ProofOfReserve::<T> {
+			status: ProposalStatus::Pending,
+			message,
+			psbt,
+			signed_psbts: BoundedVec::<ProposalSignatures<T>, T::MaxCosignersPerVault>::default(),
+		};
+		<ProofOfReserves<T>>::insert(vault_id, new_proof);
+		Self::deposit_event(Event::ProofOfReserveStored(vault_id));
+		Ok(())
+	}
 
-    pub fn do_save_proof_psbt(signer: T::AccountId, vault_id: [u8; 32], psbt: PSBT<T>, is_finalized: bool) -> DispatchResult{
-        Self::vault_comprobations(vault_id,&signer)?;
-        let signature: ProposalSignatures<T> = ProposalSignatures{
-            signer: signer.clone(),
-            signature: psbt,
-        };
-        
-        <ProofOfReserves<T>>::try_mutate::<_,(),DispatchError,_>(vault_id, |maybe_proof|{
-            maybe_proof.as_ref().ok_or(Error::<T>::ProofNotFound)?;
-            if let Some(proof) = maybe_proof {
-                let signed_already = proof.signed_psbts.iter().find(|&signature|{ signature.signer ==signer }).is_some();
-                ensure!(!signed_already, Error::<T>::AlreadySigned);
-                proof.signed_psbts.try_push(signature).map_err(|_| Error::<T>::ExceedMaxCosignersPerVault)?;
-                // this should never fail, earlier vault comprobations ensure it:
-                if proof.signed_psbts.len() as u32 >= <Vaults<T>>::get(vault_id).unwrap().threshold {
-					proof.status.clone_from( if is_finalized { &ProposalStatus::Finalized } else { &ProposalStatus::ReadyToFinalize(false)});
+	pub fn do_save_proof_psbt(
+		signer: T::AccountId,
+		vault_id: [u8; 32],
+		psbt: PSBT<T>,
+		is_finalized: bool,
+	) -> DispatchResult {
+		Self::vault_comprobations(vault_id, &signer)?;
+		let signature: ProposalSignatures<T> =
+			ProposalSignatures { signer: signer.clone(), signature: psbt };
+
+		<ProofOfReserves<T>>::try_mutate::<_, (), DispatchError, _>(vault_id, |maybe_proof| {
+			maybe_proof.as_ref().ok_or(Error::<T>::ProofNotFound)?;
+			if let Some(proof) = maybe_proof {
+				let signed_already = proof
+					.signed_psbts
+					.iter()
+					.find(|&signature| signature.signer == signer)
+					.is_some();
+				ensure!(!signed_already, Error::<T>::AlreadySigned);
+				proof
+					.signed_psbts
+					.try_push(signature)
+					.map_err(|_| Error::<T>::ExceedMaxCosignersPerVault)?;
+				// this should never fail, earlier vault comprobations ensure it:
+				if proof.signed_psbts.len() as u32 >= <Vaults<T>>::get(vault_id).unwrap().threshold
+				{
+					proof.status.clone_from(if is_finalized {
+						&ProposalStatus::Finalized
+					} else {
+						&ProposalStatus::ReadyToFinalize(false)
+					});
 				}
-            }
-            Ok(())
-        })?;
+			}
+			Ok(())
+		})?;
+		Self::deposit_event(Event::ProofPSBTStored(vault_id));
+		Ok(())
+	}
 
-        Ok(())
-    }
+	pub fn do_remove_proof(vault_id: [u8; 32]) {
+		<ProofOfReserves<T>>::remove(vault_id)
+	}
+	/*---- Utilities ----*/
 
-    /*---- Utilities ----*/
+	// check if the xpub is free to take/update or if its owned by the account
+	pub fn get_xpub_status(who: T::AccountId, xpub_hash: [u8; 32]) -> XpubStatus {
+		if <Xpubs<T>>::contains_key(xpub_hash) {
+			if let Some(owned_hash) = <XpubsByOwner<T>>::get(who.clone()) {
+				match xpub_hash == owned_hash {
+					true => return XpubStatus::Owned,
+					false => return XpubStatus::Taken,
+				}
+			} else {
+				// xpub registered and the account doesnt own it: unavailable
+				return XpubStatus::Taken;
+			}
+			// Does the user owns the registered xpub? if yes, available
+		}
+		// new xpub registry: available
+		XpubStatus::Free
+	}
 
-    // check if the xpub is free to take/update or if its owned by the account
-    pub fn get_xpub_status(who: T::AccountId, xpub_hash: [u8; 32]) -> XpubStatus {
-        if <Xpubs<T>>::contains_key(xpub_hash) {
-            if let Some(owned_hash) = <XpubsByOwner<T>>::get(who.clone()) {
-                match xpub_hash == owned_hash {
-                    true => return XpubStatus::Owned,
-                    false => return XpubStatus::Taken,
-                }
-            } else {
-                // xpub registered and the account doesnt own it: unavailable
-                return XpubStatus::Taken;
-            }
-            // Does the user owns the registered xpub? if yes, available
-        }
-        // new xpub registry: available
-        XpubStatus::Free
-    }
+	pub fn vault_comprobations(vault_id: [u8; 32], signer: &T::AccountId) -> DispatchResult {
+		let vault = <Vaults<T>>::get(vault_id).ok_or(Error::<T>::VaultNotFound)?;
+		ensure!(vault.is_vault_member(signer), Error::<T>::SignerPermissionsNeeded);
+		ensure!(vault.is_valid(), Error::<T>::InvalidVault);
+		Ok(())
+	}
 
-    pub fn vault_comprobations(vault_id: [u8; 32], signer: &T::AccountId) -> DispatchResult{
-        let vault =  <Vaults<T>>::get(vault_id).ok_or(Error::<T>::VaultNotFound)?;
-        ensure!(vault.is_vault_member(signer),Error::<T>::SignerPermissionsNeeded);
-        ensure!(vault.is_valid(), Error::<T>::InvalidVault);
-        Ok(())
-    }
+	/*---- Offchain extrinsics ----*/
 
-    /*---- Offchain extrinsics ----*/
+	pub fn do_insert_descriptors(
+		vault_id: [u8; 32],
+		descriptors: Descriptors<T::OutputDescriptorMaxLen>,
+		status: BDKStatus<T::VaultDescriptionMaxLen>,
+	) -> DispatchResult {
+		<Vaults<T>>::try_mutate(vault_id, |v| match v {
+			Some(vault) => {
+				vault.descriptors.clone_from(&descriptors);
+				vault.offchain_status.clone_from(&status);
+				Ok(())
+			},
+			None => Err(Error::<T>::VaultNotFound),
+		})?;
+		Self::deposit_event(Event::DescriptorsStored(vault_id));
+		Ok(())
+	}
 
-    pub fn do_insert_descriptors(vault_id: [u8;32], descriptors: Descriptors<T::OutputDescriptorMaxLen>, status: BDKStatus<T::VaultDescriptionMaxLen>) -> DispatchResult {
-        <Vaults<T>>::try_mutate(vault_id, | v |{
-            match v {
-                Some(vault) =>{
-                    vault.descriptors.clone_from(&descriptors);
-                    vault.offchain_status.clone_from(&status);
-                    Ok(())
-                },
-                None=> Err(Error::<T>::VaultNotFound),
-            }
-        })?;
-        Self::deposit_event(Event::DescriptorsStored(vault_id));
-        Ok(())
-    }
+	pub fn do_insert_psbt(
+		proposal_id: [u8; 32],
+		psbt: BoundedVec<u8, T::PSBTMaxLen>,
+		status: BDKStatus<T::VaultDescriptionMaxLen>,
+	) -> DispatchResult {
+		<Proposals<T>>::try_mutate(proposal_id, |p| match p {
+			Some(proposal) => {
+				proposal.psbt.clone_from(&psbt);
+				proposal.offchain_status.clone_from(&status);
+				Ok(())
+			},
+			None => Err(Error::<T>::ProposalNotFound),
+		})?;
+		Self::deposit_event(Event::PSBTStored(proposal_id));
+		Ok(())
+	}
 
-    pub fn do_insert_psbt(proposal_id: [u8;32], psbt: BoundedVec<u8, T::PSBTMaxLen>, status: BDKStatus<T::VaultDescriptionMaxLen>) ->DispatchResult{
-        <Proposals<T>>::try_mutate(proposal_id,|p|{
-            match p {
-                Some(proposal) =>{
-                    proposal.psbt.clone_from(&psbt);
-                    proposal.offchain_status.clone_from(&status);
-                    Ok(())
-                },
-                None=> Err(Error::<T>::ProposalNotFound),
-            }
-        })?;
-        Self::deposit_event(Event::PSBTStored(proposal_id));
-        Ok(())
-    }
+	pub fn do_insert_tx_id(
+		proposal_id: [u8; 32],
+		tx_id: Option<BoundedVec<u8, T::VaultDescriptionMaxLen>>,
+		status: BDKStatus<T::VaultDescriptionMaxLen>,
+	) -> DispatchResult {
+		<Proposals<T>>::try_mutate(proposal_id, |p| match p {
+			Some(proposal) => {
+				proposal.tx_id.clone_from(&tx_id);
+				proposal.offchain_status.clone_from(&status);
+				proposal.status.clone_from(&proposal.status.next_status());
+				Ok(())
+			},
+			None => Err(Error::<T>::ProposalNotFound),
+		})?;
+		Self::deposit_event(Event::ProposalTxIdStored(proposal_id));
+		Ok(())
+	}
+	/*---- Offchain utilities ----*/
 
-    pub fn do_insert_tx_id(proposal_id: [u8;32], tx_id: Option<BoundedVec<u8, T::VaultDescriptionMaxLen>>, status: BDKStatus<T::VaultDescriptionMaxLen>) -> DispatchResult {
-        <Proposals<T>>::try_mutate(proposal_id,|p|{
-            match p {
-                Some(proposal) =>{
-                    proposal.tx_id.clone_from(&tx_id);
-                    proposal.offchain_status.clone_from(&status);
-                    proposal.status.clone_from(&proposal.status.next_status() );
-                    Ok(())
-                },
-                None=> Err(Error::<T>::ProposalNotFound),
-            }
-        })?;
-        Self::deposit_event(Event::ProposalTxIdStored(proposal_id));
-        Ok(())
-    }
-    /*---- Offchain utilities ----*/
+	pub fn get_pending_vaults() -> Vec<[u8; 32]> {
+		<Vaults<T>>::iter()
+			.filter_map(|(entry, vault)| {
+				if vault.descriptors.output_descriptor.is_empty()
+					&& (vault.offchain_status.eq(&BDKStatus::<T::VaultDescriptionMaxLen>::Pending)
+						|| vault.offchain_status.eq(
+							&BDKStatus::<T::VaultDescriptionMaxLen>::RecoverableError(
+								BoundedVec::<u8, T::VaultDescriptionMaxLen>::default(),
+							),
+						)) {
+					Some(entry)
+				} else {
+					None
+				}
+			})
+			.collect()
+	}
 
-    pub fn get_pending_vaults() -> Vec<[u8; 32]> {
-        <Vaults<T>>::iter()
-            .filter_map(|(entry, vault)| {
-                if vault.descriptors.output_descriptor.is_empty() &&
-                (vault.offchain_status.eq(&BDKStatus::<T::VaultDescriptionMaxLen>::Pending) ||
-                 vault.offchain_status.eq(&BDKStatus::<T::VaultDescriptionMaxLen>::RecoverableError(
-                    BoundedVec::<u8,T::VaultDescriptionMaxLen>::default() )) )  {
-                    Some(entry)
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
+	pub fn get_pending_proposals() -> Vec<[u8; 32]> {
+		<Proposals<T>>::iter()
+			.filter_map(|(id, proposal)| {
+				if proposal.psbt.is_empty()
+					&& (proposal
+						.offchain_status
+						.eq(&BDKStatus::<T::VaultDescriptionMaxLen>::Pending)
+						|| proposal.offchain_status.eq(
+							&BDKStatus::<T::VaultDescriptionMaxLen>::RecoverableError(
+								BoundedVec::<u8, T::VaultDescriptionMaxLen>::default(),
+							),
+						)) {
+					Some(id)
+				} else {
+					None
+				}
+			})
+			.collect()
+	}
 
-    pub fn get_pending_proposals() -> Vec<[u8; 32]>{
-        <Proposals<T>>::iter()
-            .filter_map(|(id, proposal)|{
-                if proposal.psbt.is_empty() &&
-                (proposal.offchain_status.eq(&BDKStatus::<T::VaultDescriptionMaxLen>::Pending) ||
-                proposal.offchain_status.eq(&BDKStatus::<T::VaultDescriptionMaxLen>::RecoverableError(
-                    BoundedVec::<u8,T::VaultDescriptionMaxLen>::default() )) ){
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-        .collect()
-    }
+	pub fn get_accounts_xpubs(accounts: Vec<T::AccountId>) -> Result<Vec<Vec<u8>>, DispatchError> {
+		// rely on pallet storage (just in case the identity gets reseted by user error)
+		let mut xpub_vec = Vec::<Vec<u8>>::default();
+		accounts.iter().try_for_each::<_, DispatchResult>(|account| {
+			let xpub_id = <XpubsByOwner<T>>::get(account).ok_or(Error::<T>::XPubNotFound)?;
+			let xpub = <Xpubs<T>>::get(xpub_id).ok_or(Error::<T>::XPubNotFound)?;
+			xpub_vec.push(
+				// format the xpub to string
+				xpub.to_vec(),
+			);
+			Ok(())
+		})?;
+		Ok(xpub_vec)
+	}
 
-    pub fn get_accounts_xpubs(accounts: Vec<T::AccountId>) -> Result<Vec<Vec<u8>>,DispatchError> {
-        // rely on pallet storage (just in case the identity gets reseted by user error)
-        let mut xpub_vec = Vec::<Vec<u8>>::default();
-        accounts.iter().try_for_each::<_, DispatchResult>(|account| {
-            let xpub_id =
-                <XpubsByOwner<T>>::get(account).ok_or(Error::<T>::XPubNotFound)?;
-            let xpub =
-                <Xpubs<T>>::get(xpub_id).ok_or(Error::<T>::XPubNotFound)?;
-            xpub_vec.push(
-                // format the xpub to string
-                xpub.to_vec(),
-            );
-            Ok(())
-        })?;
-        Ok(xpub_vec)
-    }
+	pub fn get_proposals_to_finalize() -> Vec<[u8; 32]> {
+		// offchain status == valid and proposal status ReadyToFinalize
+		<Proposals<T>>::iter()
+			.filter_map(|(id, p)| {
+				if p.can_be_finalized() {
+					return Some(id);
+				}
+				None
+			})
+			.collect()
+	}
 
-    pub fn get_proposals_to_finalize()-> Vec<[u8;32]>{
-        // offchain status == valid and proposal status ReadyToFinalize
-        <Proposals<T>>::iter().filter_map(| (id,p) |{
-            if p.can_be_finalized() {
-                return Some(id)
-            }
-            None
-        })
-        .collect()
-    }
+	// pub fn get_proposals_to_broadcast()->  Vec<[u8;32]>{
+	//     // offchain status == valid and proposal status ready to ReadyToBroadcast
+	//     <Proposals<T>>::iter().filter_map(| (id,p) |{
+	//         if p.can_be_broadcasted() {
+	//             return Some(id)
+	//         }
+	//         None
+	//     })
+	//     .collect()
 
-    // pub fn get_proposals_to_broadcast()->  Vec<[u8;32]>{
-    //     // offchain status == valid and proposal status ready to ReadyToBroadcast
-    //     <Proposals<T>>::iter().filter_map(| (id,p) |{
-    //         if p.can_be_broadcasted() {
-    //             return Some(id)
-    //         }
-    //         None
-    //     })
-    //     .collect()
+	// }
 
-    // }
+	fn http_post(url: &str, request_body: &str) -> Result<Vec<u8>, OffchainStatus> {
+		let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(6_000));
 
-    fn http_post(url: &str, request_body: &str)->Result<Vec<u8>, OffchainStatus >{
-        let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(6_000));
+		let request = http::Request::post(&url, [request_body.clone()].to_vec())
+			.add_header("Content-Type", "application/json")
+			.add_header("Accept", "application/json");
 
-        let request = http::Request::post(
-            &url,
-            [request_body.clone()].to_vec(),
-        )
-        .add_header("Content-Type", "application/json")
-        .add_header("Accept", "application/json");
+		let pending = request
+			.body([request_body.clone()].to_vec())
+			.deadline(deadline)
+			.send()
+			.map_err(|_| Self::build_offchain_err(true, "I/O error"))?;
+		let response = pending
+			.try_wait(deadline)
+			.map_err(|_| Self::build_offchain_err(true, "Request to bdk timed out"))?
+			.map_err(|_| Self::build_offchain_err(false, "Unknown error on server's side"))?;
+		match response.code {
+			200..=299 => return Ok(response.body().collect::<Vec<u8>>()),
+			400..=499 => {
+				let vec_body = response.body().collect::<Vec<u8>>();
+				let msj_str =
+					str::from_utf8(vec_body.as_slice()).unwrap_or("Error 400: Bad request");
+				return Err(Self::build_offchain_err(false, msj_str));
+			},
+			500..=599 => {
+				let vec_body = response.body().collect::<Vec<u8>>();
+				let msj_str =
+					str::from_utf8(vec_body.as_slice()).unwrap_or("Error 500: Server error");
+				return Err(Self::build_offchain_err(false, msj_str));
+			},
+			_ => return Err(Self::build_offchain_err(true, "Unknown error")),
+		}
+	}
 
-        let pending = request
-            .body([request_body.clone()].to_vec())
-            .deadline(deadline)
-            .send()
-            .map_err(|_|
-                Self::build_offchain_err(true, "I/O error")
-            )?;
-        let response =
-            pending.try_wait(deadline).map_err(|_| Self::build_offchain_err(true, "Request to bdk timed out"))?.
-            map_err(|_|Self::build_offchain_err(false, "Unknown error on server's side"))?;
-        match response.code{
-            200..=299 => return Ok(response.body().collect::<Vec<u8>>()),
-            400..=499 => {
-                let vec_body = response.body().collect::<Vec<u8>>();
-                let msj_str = str::from_utf8(vec_body.as_slice()).unwrap_or("Error 400: Bad request");
-                return Err(Self::build_offchain_err(false, msj_str ))
-            },
-            500..=599 => {
-                let vec_body = response.body().collect::<Vec<u8>>();
-                let msj_str = str::from_utf8(vec_body.as_slice()).unwrap_or("Error 500: Server error");
-                return Err(Self::build_offchain_err(false, msj_str ))
-            }
-            _ =>return Err(Self::build_offchain_err(true, "Unknown error"))
-        }
-    }
+	pub fn extract_json_str_by_name(
+		tuple: Vec<(Vec<char>, JsonValue)>,
+		s: &str,
+	) -> Option<Vec<u8>> {
+		let filtered = tuple.into_iter().find(|(key, _)| key.iter().copied().eq(s.chars()));
+		if let Some(fields) = filtered {
+			match fields.1 {
+				JsonValue::String(chars) => return Some(Self::chars_to_bytes(chars)),
+				_ => return None,
+			}
+		}
+		None
+	}
 
-    pub fn extract_json_str_by_name( tuple: Vec<(Vec<char>, JsonValue)>,s: &str,) -> Option<Vec<u8>> {
-        let filtered = tuple.into_iter().find(|(key, _)| key.iter().copied().eq(s.chars()));
-        if let Some(fields) = filtered {
-            match fields.1 {
-                JsonValue::String(chars) => return Some(Self::chars_to_bytes(chars)),
-                _ => return None,
-            }
-        }
-        None
-    }
+	fn generate_vault_json_body(vault_id: [u8; 32]) -> Result<Vec<u8>, OffchainStatus> {
+		let mut body = Vec::new();
 
-    fn generate_vault_json_body(vault_id: [u8; 32]) -> Result<Vec<u8>, OffchainStatus >{
-        let mut body = Vec::new();
+		//Get vault properties
+		let vault = <Vaults<T>>::get(&vault_id)
+			.ok_or(Self::build_offchain_err(false, "Vault not found"))?;
+		let threshold = NumberValue {
+			integer: vault.threshold.clone().into(),
+			fraction: 0,
+			fraction_length: 0,
+			exponent: 0,
+		};
+		body.push(("threshold".chars().collect::<Vec<char>>(), JsonValue::Number(threshold)));
+		let vault_signers = vault.cosigners.clone().to_vec();
 
-        //Get vault properties
-        let vault = <Vaults<T>>::get(&vault_id).ok_or(
-            Self::build_offchain_err(false,"Vault not found"))?;
-        let threshold = NumberValue {
-            integer: vault.threshold.clone().into(),
-            fraction: 0,
-            fraction_length: 0,
-            exponent: 0,
-        };
-        body.push(("threshold".chars().collect::<Vec<char>>(), JsonValue::Number(threshold)));
-        let vault_signers = vault.cosigners.clone().to_vec();
+		//get the xpub for each cosigner
+		let xpubs = Self::get_accounts_xpubs(vault_signers).map_err(|_| {
+			Self::build_offchain_err(false, "One of the cosigner xpubs wasn't found")
+		})?;
+		let mapped_xpubs: Vec<JsonValue> = xpubs
+			.iter()
+			.map(|xpub| {
+				let xpub_field = JsonValue::String(str::from_utf8(xpub).unwrap().chars().collect());
+				JsonValue::Object([("xpub".chars().collect(), xpub_field)].to_vec())
+			})
+			.collect();
+		body.push(("cosigners".chars().collect::<Vec<char>>(), JsonValue::Array(mapped_xpubs)));
+		let json_object = JsonValue::Object(body);
 
-        //get the xpub for each cosigner
-        let xpubs = Self::get_accounts_xpubs(vault_signers).map_err(|_|
-            Self::build_offchain_err(false, "One of the cosigner xpubs wasn't found"))?;
-        let mapped_xpubs: Vec<JsonValue> = xpubs.iter()
-            .map(|xpub| {
-                let xpub_field =
-                    JsonValue::String(str::from_utf8(xpub).unwrap().chars().collect());
-                JsonValue::Object([("xpub".chars().collect(), xpub_field)].to_vec())
-            })
-            .collect();
-        body.push(("cosigners".chars().collect::<Vec<char>>(), JsonValue::Array(mapped_xpubs)));
-        let json_object = JsonValue::Object(body);
+		// // Parse the JSON and print the resulting lite-json structure.
+		Ok(jsonSerialize::format(&json_object, 4))
+	}
 
-        // // Parse the JSON and print the resulting lite-json structure.
-        Ok(jsonSerialize::format(&json_object, 4))
-    }
+	/// Parse the descriptors from the given JSON string using `lite-json`.
+	///
+	/// Returns `None` when parsing failed or `Some((descriptor, change_descriptor))` when parsing is successful.
+	fn parse_vault_descriptors(body_str: &str) -> Result<(Vec<u8>, Vec<u8>), OffchainStatus> {
+		let val = parse_json(body_str);
+		match val.ok() {
+			Some(JsonValue::Object(obj)) => {
+				let descriptor = Self::extract_json_str_by_name(obj.clone(), "descriptor").ok_or(
+					Self::build_offchain_err(false, "Descriptor not found in bdk response"),
+				)?;
+				let change_descriptor =
+					Self::extract_json_str_by_name(obj.clone(), "change_descriptor").ok_or(
+						Self::build_offchain_err(
+							false,
+							"Change descriptor not found in bdk response",
+						),
+					)?;
+				Ok((descriptor, change_descriptor))
+			},
+			_ => return Err(Self::build_offchain_err(false, "Error parsing response json")),
+		}
+	}
 
-    /// Parse the descriptors from the given JSON string using `lite-json`.
-    ///
-    /// Returns `None` when parsing failed or `Some((descriptor, change_descriptor))` when parsing is successful.
-    fn parse_vault_descriptors(body_str: &str) -> Result<(Vec<u8>, Vec<u8>), OffchainStatus > {
-        let val = parse_json(body_str);
-        match val.ok() {
-            Some(JsonValue::Object(obj) )=> {
-                let descriptor = Self::extract_json_str_by_name(obj.clone(), "descriptor")
-                    .ok_or(Self::build_offchain_err(false,"Descriptor not found in bdk response"))?;
-                let change_descriptor =
-                    Self::extract_json_str_by_name(obj.clone(), "change_descriptor")
-                        .ok_or(Self::build_offchain_err(false,"Change descriptor not found in bdk response"))?;
-                Ok((descriptor, change_descriptor))
-            },
-            _ => {
-                return Err(Self::build_offchain_err(false,"Error parsing response json"))
-            },
-        }
-    }
+	pub fn bdk_gen_vault(vault_id: [u8; 32]) -> Result<(Vec<u8>, Vec<u8>), OffchainStatus> {
+		// We will create a bunch of elements that we will put into a JSON Object.
+		let raw_json = Self::generate_vault_json_body(vault_id)?;
+		let request_body = str::from_utf8(raw_json.as_slice())
+			.map_err(|_| Self::build_offchain_err(false, "Vault json is not utf-8"))?;
 
-    pub fn bdk_gen_vault(vault_id: [u8; 32]) -> Result<(Vec<u8>, Vec<u8>), OffchainStatus > {
-        // We will create a bunch of elements that we will put into a JSON Object.
-        let raw_json = Self::generate_vault_json_body(vault_id)?;
-        let request_body =
-        str::from_utf8(raw_json.as_slice()).map_err(|_| Self::build_offchain_err(false, "Vault json is not utf-8") )?;
+		let url =
+			[<BDKServicesURL<T>>::get().to_vec(), b"/gen_output_descriptor".encode()].concat();
+		let response_body = Self::http_post(
+			str::from_utf8(url.as_slice())
+				.map_err(|_| Self::build_offchain_err(false, "URL is not utf-8"))?,
+			request_body,
+		)?;
+		// Create a str slice from the body.
+		let body_str = str::from_utf8(&response_body).map_err(|_| {
+			log::warn!("No UTF8 body");
+			Self::build_offchain_err(false, "No UTF8 body")
+		})?;
 
-        let url = [<BDKServicesURL<T>>::get().to_vec(), b"/gen_output_descriptor".encode()].concat();
-        let response_body = Self::http_post(
-            str::from_utf8(url.as_slice()).map_err(|_| Self::build_offchain_err(false, "URL is not utf-8") )?,
-            request_body
-        )?;
-        // Create a str slice from the body.
-        let body_str = str::from_utf8(&response_body).map_err(|_| {
-            log::warn!("No UTF8 body");
-            Self::build_offchain_err(false, "No UTF8 body")
-        })?;
+		Self::parse_vault_descriptors(body_str)
+	}
 
-        Self::parse_vault_descriptors(body_str)
-    }
+	pub fn gen_vaults_payload_by_bulk(pending_vaults: Vec<[u8; 32]>) -> Vec<SingleVaultPayload> {
+		let mut generated_vaults = Vec::<SingleVaultPayload>::new();
+		pending_vaults.iter().for_each(|vault_to_complete| {
+			// Contact bdk services and get descriptors
+			let vault_result = Self::bdk_gen_vault(vault_to_complete.clone());
+			let mut vault_payload = SingleVaultPayload {
+				vault_id: vault_to_complete.clone(),
+				output_descriptor: Vec::default(),
+				change_descriptor: Vec::default(),
+				status: OffchainStatus::Valid,
+			};
+			match vault_result {
+				Ok(descriptors) => {
+					vault_payload.output_descriptor.clone_from(&descriptors.0);
+					vault_payload.change_descriptor.clone_from(&descriptors.1);
+				},
+				Err(status) => vault_payload.status.clone_from(&status),
+			};
+			// Build offchain vaults struct and push it to a Vec
+			generated_vaults.push(vault_payload);
+		});
+		generated_vaults
+	}
 
-    pub fn gen_vaults_payload_by_bulk(pending_vaults : Vec<[u8;32]>) -> Vec<SingleVaultPayload >{
-        let mut generated_vaults = Vec::<SingleVaultPayload >::new();
-        pending_vaults.iter().for_each(|vault_to_complete| {
-            // Contact bdk services and get descriptors
-            let vault_result = Self::bdk_gen_vault(vault_to_complete.clone());
-            let mut vault_payload = SingleVaultPayload{
-                vault_id: vault_to_complete.clone(),
-                output_descriptor: Vec::default(),
-                change_descriptor: Vec::default(),
-                status: OffchainStatus::Valid,
-            };
-            match vault_result{
-                Ok(descriptors) => {
-                    vault_payload.output_descriptor.clone_from(&descriptors.0);
-                    vault_payload.change_descriptor.clone_from(&descriptors.1);
-                },
-                Err(status) => {vault_payload.status.clone_from(&status)},
-            };
-            // Build offchain vaults struct and push it to a Vec
-            generated_vaults.push(vault_payload);
-        });
-        generated_vaults
-    }
+	pub fn gen_proposal_json_body(proposal_id: [u8; 32]) -> Result<Vec<u8>, OffchainStatus> {
+		let mut body = Vec::new();
+		let proposal = <Proposals<T>>::get(proposal_id)
+			.ok_or(Self::build_offchain_err(false, "Proposal not found"))?;
+		let vault = <Vaults<T>>::get(proposal.vault_id.clone())
+			.ok_or(Self::build_offchain_err(false, "Vault not found"))?;
+		let amount = NumberValue {
+			integer: proposal.amount.clone() as i64,
+			fraction: 0,
+			fraction_length: 0,
+			exponent: 0,
+		};
+		let fee = NumberValue {
+			integer: proposal.fee_sat_per_vb.clone().into(),
+			fraction: 0,
+			fraction_length: 0,
+			exponent: 0,
+		};
+		let to_address = str::from_utf8(proposal.to_address.as_slice())
+			.map_err(|_| {
+				Self::build_offchain_err(false, "Error converting the recipiend addres to utf-8")
+			})?
+			.chars()
+			.collect();
+		let output_descriptor: Vec<char> =
+			str::from_utf8(vault.descriptors.output_descriptor.as_slice())
+				.map_err(|_| Self::build_offchain_err(false, "Output descriptor is not utf-8"))?
+				.chars()
+				.collect();
+		let change_descriptor: Vec<char> =
+			str::from_utf8(vault.descriptors.change_descriptor.unwrap_or_default().as_slice())
+				.map_err(|_| Self::build_offchain_err(false, "Change descriptor is not utf-8"))?
+				.chars()
+				.collect();
+		let descriptors_body = [
+			("descriptor".chars().collect::<Vec<char>>(), JsonValue::String(output_descriptor)),
+			(
+				"change_descriptor".chars().collect::<Vec<char>>(),
+				JsonValue::String(change_descriptor),
+			),
+		]
+		.to_vec();
+		body.push(("amount".chars().collect::<Vec<char>>(), JsonValue::Number(amount)));
+		body.push(("fee_sat_per_vb".chars().collect::<Vec<char>>(), JsonValue::Number(fee)));
+		body.push(("to_address".chars().collect::<Vec<char>>(), JsonValue::String(to_address)));
+		body.push((
+			"descriptors".chars().collect::<Vec<char>>(),
+			JsonValue::Object(descriptors_body),
+		));
+		let json_object = JsonValue::Object(body);
 
-    pub fn gen_proposal_json_body(proposal_id: [u8;32])-> Result<Vec<u8>,OffchainStatus>{
-        let mut body = Vec::new();
-        let proposal = <Proposals<T>>::get(proposal_id).ok_or(
-            Self::build_offchain_err(false,"Proposal not found"))?;
-        let vault = <Vaults<T>>::get(proposal.vault_id.clone()).ok_or(
-            Self::build_offchain_err(false,"Vault not found"))?;
-        let amount = NumberValue {
-            integer: proposal.amount.clone() as i64,
-            fraction: 0,
-            fraction_length: 0,
-            exponent: 0,
-        };
-        let fee = NumberValue {
-            integer: proposal.fee_sat_per_vb.clone().into(),
-            fraction: 0,
-            fraction_length: 0,
-            exponent: 0,
-        };
-        let to_address = str::from_utf8(proposal.to_address.as_slice())
-            .map_err(|_| Self::build_offchain_err(false,"Error converting the recipiend addres to utf-8"))?.chars().collect();
-        let output_descriptor: Vec<char> = str::from_utf8(
-            vault.descriptors.output_descriptor.as_slice())
-            .map_err(|_| Self::build_offchain_err(false,"Output descriptor is not utf-8"))?.chars().collect();
-        let change_descriptor: Vec<char> = str::from_utf8(
-            vault.descriptors.change_descriptor.unwrap_or_default().as_slice() )
-            .map_err(|_| Self::build_offchain_err(false,"Change descriptor is not utf-8"))?.chars().collect();
-        let descriptors_body = [
-            ("descriptor".chars().collect::<Vec<char>>(), JsonValue::String(output_descriptor)),
-            ("change_descriptor".chars().collect::<Vec<char>>(), JsonValue::String(change_descriptor)),
-        ].to_vec();
-        body.push(("amount".chars().collect::<Vec<char>>(), JsonValue::Number(amount) ));
-        body.push(("fee_sat_per_vb".chars().collect::<Vec<char>>(), JsonValue::Number(fee) ));
-        body.push(("to_address".chars().collect::<Vec<char>>(), JsonValue::String(to_address) ));
-        body.push(("descriptors".chars().collect::<Vec<char>>(), JsonValue::Object(descriptors_body) ));
-        let json_object = JsonValue::Object(body);
+		// // Parse the JSON and print the resulting lite-json structure.
+		Ok(jsonSerialize::format(&json_object, 4))
+	}
 
-        // // Parse the JSON and print the resulting lite-json structure.
-        Ok(jsonSerialize::format(&json_object, 4) )
-    }
+	pub fn bdk_gen_proposal(
+		proposal_id: [u8; 32],
+		api_endpoint: Vec<u8>,
+		json_builder: &dyn Fn([u8; 32]) -> Result<Vec<u8>, OffchainStatus>,
+	) -> Result<Vec<u8>, OffchainStatus> {
+		let raw_json = json_builder(proposal_id)?;
+		let request_body = str::from_utf8(raw_json.as_slice())
+			.map_err(|_| Self::build_offchain_err(false, "Request body is not UTF-8"))?;
 
-    pub fn bdk_gen_proposal(proposal_id: [u8;32], api_endpoint: Vec<u8>,
-        json_builder: &dyn Fn([u8;32])-> Result<Vec<u8>,OffchainStatus>
-    )->Result<Vec<u8>, OffchainStatus >{
-        let raw_json = json_builder(proposal_id)?;
-        let request_body =
-            str::from_utf8(raw_json.as_slice()).map_err(|_| Self::build_offchain_err(false, "Request body is not UTF-8") )?;
+		let url = [<BDKServicesURL<T>>::get().to_vec(), api_endpoint].concat();
 
-        let url = [<BDKServicesURL<T>>::get().to_vec(), api_endpoint].concat();
+		let response_body = Self::http_post(
+			str::from_utf8(url.as_slice())
+				.map_err(|_| Self::build_offchain_err(false, "URL is not UTF-8"))?,
+			request_body,
+		)?;
+		// The psbt is not a json object, its a byte blob
+		Ok(response_body)
+	}
 
-        let response_body = Self::http_post(
-            str::from_utf8(url.as_slice()).map_err(|_| Self::build_offchain_err(false, "URL is not UTF-8") )?,
-            request_body
-        )?;
-        // The psbt is not a json object, its a byte blob
-        Ok(response_body)
-    }
+	pub fn gen_proposals_payload_by_bulk(
+		pending_proposals: Vec<[u8; 32]>,
+		api_endpoint: Vec<u8>,
+		json_builder: &dyn Fn([u8; 32]) -> Result<Vec<u8>, OffchainStatus>,
+	) -> Vec<SingleProposalPayload> {
+		let mut generated_proposals = Vec::<SingleProposalPayload>::new();
+		pending_proposals.iter().for_each(|proposal_to_complete| {
+			let mut proposal_payload = SingleProposalPayload {
+				proposal_id: proposal_to_complete.clone(),
+				psbt: Vec::default(),
+				status: OffchainStatus::Valid,
+			};
+			let psbt_result = Self::bdk_gen_proposal(
+				proposal_to_complete.clone(),
+				api_endpoint.clone(),
+				json_builder,
+			);
+			match psbt_result {
+				Ok(psbt) => proposal_payload.psbt.clone_from(&psbt),
+				Err(status) => proposal_payload.status.clone_from(&status),
+			};
+			generated_proposals.push(proposal_payload);
+		});
+		generated_proposals
+	}
 
-    pub fn gen_proposals_payload_by_bulk(pending_proposals : Vec<[u8;32]>, api_endpoint: Vec<u8>,
-        json_builder: &dyn Fn([u8;32])-> Result<Vec<u8>,OffchainStatus>
-    ) ->  Vec<SingleProposalPayload>{
-        let mut generated_proposals = Vec::<SingleProposalPayload>::new();
-        pending_proposals.iter().for_each(|proposal_to_complete|{
-            let mut proposal_payload = SingleProposalPayload{
-                proposal_id:proposal_to_complete.clone(),
-                psbt : Vec::default(),
-                status: OffchainStatus::Valid,
-            };
-            let psbt_result = Self::bdk_gen_proposal(proposal_to_complete.clone(), api_endpoint.clone(),
-                json_builder);
-            match psbt_result{
-                Ok(psbt) => {proposal_payload.psbt.clone_from(&psbt)},
-                Err(status) => {proposal_payload.status.clone_from(&status)},
-            };
-            generated_proposals.push(proposal_payload);
-        });
-        generated_proposals
-    }
+	pub fn gen_finalize_json_body(proposal_id: [u8; 32]) -> Result<Vec<u8>, OffchainStatus> {
+		let mut body = Vec::new();
+		let proposal = <Proposals<T>>::get(proposal_id)
+			.ok_or(Self::build_offchain_err(false, "Proposal not found"))?;
+		let vault = <Vaults<T>>::get(proposal.vault_id.clone())
+			.ok_or(Self::build_offchain_err(false, "Vault not found"))?;
+		let output_descriptor: Vec<char> =
+			str::from_utf8(vault.descriptors.output_descriptor.as_slice())
+				.map_err(|_| Self::build_offchain_err(false, "Output descriptor is not utf-8"))?
+				.chars()
+				.collect();
+		let change_descriptor: Vec<char> =
+			str::from_utf8(vault.descriptors.change_descriptor.unwrap_or_default().as_slice())
+				.map_err(|_| Self::build_offchain_err(false, "Change descriptor is not utf-8"))?
+				.chars()
+				.collect();
+		let descriptors_body = [
+			("descriptor".chars().collect::<Vec<char>>(), JsonValue::String(output_descriptor)),
+			(
+				"change_descriptor".chars().collect::<Vec<char>>(),
+				JsonValue::String(change_descriptor),
+			),
+		]
+		.to_vec();
+		let mapped_signatures: Vec<JsonValue> = proposal
+			.signed_psbts
+			.iter()
+			.map(|psbt| {
+				JsonValue::String(
+					str::from_utf8(&psbt.signature).unwrap_or_default().chars().collect(),
+				)
+			})
+			.collect();
 
-    pub fn gen_finalize_json_body(proposal_id: [u8;32])-> Result<Vec<u8>,OffchainStatus>{
-        let mut body = Vec::new();
-        let proposal = <Proposals<T>>::get(proposal_id).ok_or(
-            Self::build_offchain_err(false,"Proposal not found"))?;
-        let vault = <Vaults<T>>::get(proposal.vault_id.clone()).ok_or(
-            Self::build_offchain_err(false,"Vault not found"))?;
-        let output_descriptor: Vec<char> = str::from_utf8(
-            vault.descriptors.output_descriptor.as_slice())
-            .map_err(|_| Self::build_offchain_err(false,"Output descriptor is not utf-8"))?.chars().collect();
-        let change_descriptor: Vec<char> = str::from_utf8(
-            vault.descriptors.change_descriptor.unwrap_or_default().as_slice() )
-            .map_err(|_| Self::build_offchain_err(false,"Change descriptor is not utf-8"))?.chars().collect();
-        let descriptors_body = [
-            ("descriptor".chars().collect::<Vec<char>>(), JsonValue::String(output_descriptor)),
-            ("change_descriptor".chars().collect::<Vec<char>>(), JsonValue::String(change_descriptor)),].to_vec();
-        let mapped_signatures: Vec<JsonValue> = proposal.signed_psbts.iter().map(|psbt|{
-            JsonValue::String(str::from_utf8(&psbt.signature).unwrap_or_default().chars().collect())
-        }).collect();
+		let broadcast = match proposal.status {
+			ProposalStatus::ReadyToFinalize(flag) => flag,
+			_ => false,
+		};
+		body.push(("psbts".chars().collect::<Vec<char>>(), JsonValue::Array(mapped_signatures)));
+		body.push((
+			"descriptors".chars().collect::<Vec<char>>(),
+			JsonValue::Object(descriptors_body),
+		));
+		body.push(("broadcast".chars().collect::<Vec<char>>(), JsonValue::Boolean(broadcast)));
+		let json_object = JsonValue::Object(body);
 
-        let broadcast= match proposal.status{
-            ProposalStatus::ReadyToFinalize(flag) => flag,
-            _ => false,
-        };
-        body.push(("psbts".chars().collect::<Vec<char>>(), JsonValue::Array(mapped_signatures)));
-        body.push(("descriptors".chars().collect::<Vec<char>>(), JsonValue::Object(descriptors_body) ));
-        body.push(("broadcast".chars().collect::<Vec<char>>(), JsonValue::Boolean(broadcast) ));
-        let json_object = JsonValue::Object(body);
+		// // Parse the JSON and print the resulting lite-json structure.
+		Ok(jsonSerialize::format(&json_object, 4))
+	}
 
-        // // Parse the JSON and print the resulting lite-json structure.
-        Ok(jsonSerialize::format(&json_object, 4) )
-    }
+	// pub fn bdk_gen_finalized_proposal(proposal_id: [u8;32])-> Result<Vec<u8>,OffchainStatus >{
+	//     let raw_json = Self::gen_finalize_json_body(proposal_id)?;
+	//     let request_body =
+	//         str::from_utf8(raw_json.as_slice()).map_err(|_| Self::build_offchain_err(false, "Request body is not UTF-8") )?;
 
-    // pub fn bdk_gen_finalized_proposal(proposal_id: [u8;32])-> Result<Vec<u8>,OffchainStatus >{
-    //     let raw_json = Self::gen_finalize_json_body(proposal_id)?;
-    //     let request_body =
-    //         str::from_utf8(raw_json.as_slice()).map_err(|_| Self::build_offchain_err(false, "Request body is not UTF-8") )?;
+	//     let url = [<BDKServicesURL<T>>::get().to_vec(), b"/finalize_trx".encode()].concat();
 
-    //     let url = [<BDKServicesURL<T>>::get().to_vec(), b"/finalize_trx".encode()].concat();
+	//     let response_body = Self::http_post(
+	//         str::from_utf8(url.as_slice()).map_err(|_| Self::build_offchain_err(false, "URL is not UTF-8") )?,
+	//         request_body
+	//     )?;
+	//     // The psbt is not a json object, its a byte blob
+	//     Ok(response_body)
+	// }
 
-    //     let response_body = Self::http_post(
-    //         str::from_utf8(url.as_slice()).map_err(|_| Self::build_offchain_err(false, "URL is not UTF-8") )?,
-    //         request_body
-    //     )?;
-    //     // The psbt is not a json object, its a byte blob
-    //     Ok(response_body)
-    // }
+	// pub fn gen_finalized_proposals_by_bulk(proposals_to_finalize : Vec<[u8;32]>) -> Vec<u8>{
+	//     let mut finalized_proposals = Vec::<SingleProposalPayload>::new();
+	//     finalized_proposals
+	// }
 
-    // pub fn gen_finalized_proposals_by_bulk(proposals_to_finalize : Vec<[u8;32]>) -> Vec<u8>{
-    //     let mut finalized_proposals = Vec::<SingleProposalPayload>::new();
-    //     finalized_proposals
-    // }
+	fn build_offchain_err(recoverable: bool, msj: &str) -> OffchainStatus {
+		let bounded_msj = msj.as_bytes().to_vec();
+		match recoverable {
+			true => OffchainStatus::RecoverableError(bounded_msj),
+			false => OffchainStatus::IrrecoverableError(bounded_msj),
+		}
+	}
 
-    fn build_offchain_err(recoverable: bool, msj: &str )-> OffchainStatus{
-        let bounded_msj = msj.as_bytes().to_vec();
-        match recoverable{
-            true => OffchainStatus::RecoverableError(bounded_msj),
-            false => OffchainStatus::IrrecoverableError(bounded_msj),
-        }
-    }
+	pub fn send_ocw_insert_descriptors(
+		generated_vaults: Vec<SingleVaultPayload>,
+		signer: &Signer<T, T::AuthorityId>,
+	) {
+		if let Some((_, res)) = signer.send_unsigned_transaction(
+			// this line is to prepare and return payload
+			|acct| VaultsPayload {
+				vaults_payload: generated_vaults.clone(),
+				public: acct.public.clone(),
+			},
+			|payload, signature| Call::ocw_insert_descriptors { payload, signature },
+		) {
+			match res {
+				Ok(()) => log::info!(
+					"Insert Descriptors: unsigned tx with signed vault payload successfully sent."
+				),
+				Err(()) => log::error!(
+					"Insert Descriptors: sending unsigned tx with signed vault payload failed."
+				),
+			};
+		}
+	}
+	pub fn send_ocw_insert_psbts(
+		generated_proposals: Vec<SingleProposalPayload>,
+		signer: &Signer<T, T::AuthorityId>,
+	) {
+		if let Some((_, res)) = signer.send_unsigned_transaction(
+			// this line is to prepare and return payload
+			|acct| ProposalsPayload {
+				proposals_payload: generated_proposals.clone(),
+				public: acct.public.clone(),
+			},
+			|payload, signature| Call::ocw_insert_psbts { payload, signature },
+		) {
+			match res {
+				Ok(()) => {
+					log::info!("Insert PSBTS: unsigned tx with signed payload successfully sent.")
+				},
+				Err(()) => {
+					log::error!("Insert PSBTS: sending unsigned tx with signed payload failed.")
+				},
+			};
+		} else {
+			// The case of `None`: no account is available for sending
+			log::error!("No local account available");
+		}
+	}
 
-    pub fn send_ocw_insert_descriptors( generated_vaults : Vec<SingleVaultPayload>, signer: &Signer<T, T::AuthorityId>){
-        if let Some((_, res)) = signer.send_unsigned_transaction(
-            // this line is to prepare and return payload
-            |acct| VaultsPayload {
-                vaults_payload: generated_vaults.clone(),
-                public: acct.public.clone(),
-            },
-            |payload, signature| Call::ocw_insert_descriptors { payload, signature },
-        ) {
-            match res {
-                Ok(()) => log::info!("Insert Descriptors: unsigned tx with signed vault payload successfully sent."),
-                Err(()) => log::error!("Insert Descriptors: sending unsigned tx with signed vault payload failed."),
-            };
-        }
-    }
-    pub fn send_ocw_insert_psbts( generated_proposals : Vec<SingleProposalPayload>, signer: &Signer<T, T::AuthorityId>){
-        if let Some((_, res)) = signer.send_unsigned_transaction(
-            // this line is to prepare and return payload
-            |acct| ProposalsPayload {
-                proposals_payload: generated_proposals.clone(),
-                public: acct.public.clone(),
-            },
-            |payload, signature| Call::ocw_insert_psbts { payload, signature },
-        ) {
-            match res {
-                Ok(()) => log::info!("Insert PSBTS: unsigned tx with signed payload successfully sent."),
-                Err(()) => log::error!("Insert PSBTS: sending unsigned tx with signed payload failed."),
-            };
-        } else {
-            // The case of `None`: no account is available for sending
-            log::error!("No local account available");
-        }
-    }
+	pub fn send_ocw_finalize_psbts(
+		generated_proposals: Vec<SingleProposalPayload>,
+		signer: &Signer<T, T::AuthorityId>,
+	) {
+		if let Some((_, res)) = signer.send_unsigned_transaction(
+			// this line is to prepare and return payload
+			|acct| ProposalsPayload {
+				proposals_payload: generated_proposals.clone(),
+				public: acct.public.clone(),
+			},
+			|payload, signature| Call::ocw_finalize_psbts { payload, signature },
+		) {
+			match res {
+				Ok(()) => {
+					log::info!("Finalize PSBTS: unsigned tx with signed payload successfully sent.")
+				},
+				Err(()) => {
+					log::error!("Finalize PSBTS: sending unsigned tx with signed payload failed.")
+				},
+			};
+		} else {
+			// The case of `None`: no account is available for sending
+			log::error!("No local account available");
+		}
+	}
 
-    pub fn send_ocw_finalize_psbts( generated_proposals : Vec<SingleProposalPayload>, signer: &Signer<T, T::AuthorityId>){
-        if let Some((_, res)) = signer.send_unsigned_transaction(
-            // this line is to prepare and return payload
-            |acct| ProposalsPayload {
-                proposals_payload: generated_proposals.clone(),
-                public: acct.public.clone(),
-            },
-            |payload, signature| Call::ocw_finalize_psbts { payload, signature },
-        ) {
-            match res {
-                Ok(()) => log::info!("Finalize PSBTS: unsigned tx with signed payload successfully sent."),
-                Err(()) => log::error!("Finalize PSBTS: sending unsigned tx with signed payload failed."),
-            };
-        } else {
-            // The case of `None`: no account is available for sending
-            log::error!("No local account available");
-        }
-    }
-
-    pub fn chars_to_bytes(v: Vec<char>) -> Vec<u8> {
-        v.iter().map(|c| *c as u8).collect::<Vec<u8>>()
-    }
+	pub fn chars_to_bytes(v: Vec<char>) -> Vec<u8> {
+		v.iter().map(|c| *c as u8).collect::<Vec<u8>>()
+	}
 }
 
 /*--- Block Number provider section. Needed to implement locks on offchain storage*/
 impl<T: Config> BlockNumberProvider for Pallet<T> {
-    type BlockNumber = T::BlockNumber;
+	type BlockNumber = T::BlockNumber;
 
-    fn current_block_number() -> Self::BlockNumber {
-        <frame_system::Pallet<T>>::block_number()
-    }
+	fn current_block_number() -> Self::BlockNumber {
+		<frame_system::Pallet<T>>::block_number()
+	}
 }

--- a/pallets/bitcoin-vaults/src/lib.rs
+++ b/pallets/bitcoin-vaults/src/lib.rs
@@ -119,6 +119,10 @@ pub mod pallet {
 		ProposalFinalized([u8; 32], T::AccountId),
 		/// A proposal tx has been inserted by an OCW
 		ProposalTxIdStored([u8; 32]),
+		/// A proof of reserve was stored for the vault
+		ProofOfReserveStored([u8; 32]),
+		/// A psbt was stored for the vaults Proof of reserve
+		ProofPSBTStored([u8; 32]),
 	}
 
 	// Errors inform users that something went wrong.
@@ -237,8 +241,8 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
-	/// Stores vaults proof-of-reserve 
-	/// 
+	/// Stores vaults proof-of-reserve
+	///
 	#[pallet::storage]
 	#[pallet::getter(fn proof_of_reserve)]
 	pub(super) type ProofOfReserves<T: Config> = StorageMap<
@@ -607,19 +611,41 @@ pub mod pallet {
 			Self::do_finalize_psbt(who, proposal_id, true)
 		}
 
-
 		/// Create Proof of Reserve
+		///
+		/// Stores a PoR for a defined vault.
+		///
+		/// ### Parameters:
+		/// - `vault_id`: the vault identifier in which the proof will be inserted
+		/// - `message`: the message to be taken into account to generate the PoR PSBT
+		/// - `psbt`: the psbt generated from bdk
+		///
+		/// ### Considerations:
+		/// - Any vault member can perform this extrinsic
+		/// - A vault can only have a PoR at a time.
 		#[pallet::weight(Weight::from_ref_time(10_000) + T::DbWeight::get().writes(1))]
 		pub fn create_proof(
 			origin: OriginFor<T>,
 			vault_id: [u8; 32],
 			message: Description<T>,
-			psbt: PSBT<T>
-		) -> DispatchResult{
+			psbt: PSBT<T>,
+		) -> DispatchResult {
 			let who = ensure_signed(origin.clone())?;
-			Self::do_create_proof(who, vault_id, message,psbt)
+			Self::do_create_proof(who, vault_id, message, psbt)
 		}
 
+		/// Save Proof of reserve PSBT
+		///
+		/// Updates the PoR with a new PSBT
+		///
+		/// ### Parameters
+		/// - `vault_id`: the vault identifier in which the proof is
+		/// - `psbt`: the new psbt to insert, the signer will be linked to it.
+		/// - `ìs_finalized`: the PoR was broadcasted (or not)
+		///
+		/// ### Considerations:
+		/// - Any vault member can perform this extrinsic
+		/// - A vault signer can only sabe its PSBT once.
 		#[pallet::weight(Weight::from_ref_time(10_000) + T::DbWeight::get().writes(1))]
 		pub fn save_proof_psbt(
 			origin: OriginFor<T>,
@@ -645,7 +671,7 @@ pub mod pallet {
 			let _ = <ProposalsByVault<T>>::clear(1000, None);
 			let _ = <Vaults<T>>::clear(1000, None);
 			let _ = <VaultsBySigner<T>>::clear(1000, None);
-			let _ = <ProofOfReserves<T>>::clear(1000,None);
+			let _ = <ProofOfReserves<T>>::clear(1000, None);
 			Ok(())
 		}
 

--- a/pallets/bitcoin-vaults/src/tests.rs
+++ b/pallets/bitcoin-vaults/src/tests.rs
@@ -1,73 +1,73 @@
-
-use crate::{mock::*, Error, types::{ProposalStatus, BDKStatus, Descriptors}, Vaults, Proposals};
-use core::convert::TryFrom;
-use codec::{Encode};
-use frame_support::{
-	assert_noop, assert_ok,
-	BoundedVec,
+use crate::{
+	mock::*,
+	types::{BDKStatus, Descriptors, ProposalStatus},
+	Error, ProofOfReserves, Proposals, Vaults,
 };
+use codec::Encode;
+use core::convert::TryFrom;
+use frame_support::{assert_noop, assert_ok, BoundedVec};
 use sp_io::hashing::blake2_256;
 
-fn dummy_xpub() -> BoundedVec<u8,XPubLen >{
+fn dummy_xpub() -> BoundedVec<u8, XPubLen> {
 	BoundedVec::<u8,XPubLen >::try_from(
 		b"[adc450e3/84'/1'/0'/0]tpubDEMkzn5sBo8Nct35y2BEFhJTqhsa72yeUf5S6ymb85G6LW2okSh1fDkrMhgCtYsrsCAuspm4yVjC63VUA6qrcQ54tVm5TKwhWFBLyyCjabX/*"
 		.encode())
 	.expect("Error on encoding the xpub key to BoundedVec")
 }
 
-fn dummy_xpub_2() -> BoundedVec<u8,XPubLen >{
+fn dummy_xpub_2() -> BoundedVec<u8, XPubLen> {
 	BoundedVec::<u8,XPubLen >::try_from(
 		b"[621c051d/123456789'/123456789'/123456789'/123456789]tpubDF3cwMypW7CJnZ4WwzwgYkd1bJzJsPTnLbFN3zdeGKfEx38jDjBzRntupghKC6A5szrjELasjrhBRXStKKUmS8wHZQxkVPN7P88iXxbC3s1/*"
 		.encode())
 	.expect("Error on encoding the xpub key to BoundedVec")
 }
 
-fn dummy_xpub_3() -> BoundedVec<u8,XPubLen> {
+fn dummy_xpub_3() -> BoundedVec<u8, XPubLen> {
 	BoundedVec::<u8,XPubLen >::try_from(b"Zpub74kbYv5LXvBaJRcbSiihEEwuDiBSDztjtpSVmt6C6nB3ntbcEy4pLP3cJGVWsKbYKaAynfCwXnkuVncPGQ9Y4XwWJDWrDMUwTztdxBe7GcM"
 		.encode())
 	.expect("Error on encoding the xpub key to BoundedVec")
 }
 
-fn dummy_xpub_4() -> BoundedVec<u8,XPubLen> {
+fn dummy_xpub_4() -> BoundedVec<u8, XPubLen> {
 	BoundedVec::<u8,XPubLen >::try_from(b"Zpub75bKLk9fCjgfELzLr2XS5TEcCXXGrci4EDwAcppFNBDwpNy53JhJS8cbRjdv39noPDKSfzK7EPC1Ciyfb7jRwY7DmiuYJ6WDr2nEL6yTkHi"
 		.encode())
 	.expect("Error on encoding the xpub key to BoundedVec")
 }
 
-fn dummy_description() ->  BoundedVec<u8, VaultDescriptionMaxLen>{
+fn dummy_description() -> BoundedVec<u8, VaultDescriptionMaxLen> {
 	BoundedVec::<u8,VaultDescriptionMaxLen>::try_from(b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.".encode())
 				.expect("Error on encoding the description to BoundedVec")
 }
 
-fn dummy_testnet_recipient_address() ->BoundedVec<u8,XPubLen> {
-	BoundedVec::<u8,XPubLen >::try_from(b"tb1qhfku74zsrhvre7053xqsnh36gsey3ur7slwwnfn04g5506rmdchqrf7w30"
-		.encode())
+fn dummy_testnet_recipient_address() -> BoundedVec<u8, XPubLen> {
+	BoundedVec::<u8, XPubLen>::try_from(
+		b"tb1qhfku74zsrhvre7053xqsnh36gsey3ur7slwwnfn04g5506rmdchqrf7w30".encode(),
+	)
 	.expect("Error on encoding the xpub key to BoundedVec")
 }
 
-fn dummy_psbt() -> BoundedVec<u8, PSBTMaxLen>{
+fn dummy_psbt() -> BoundedVec<u8, PSBTMaxLen> {
 	BoundedVec::<u8, PSBTMaxLen>::try_from(b"cHNidP8BAK4BAAAAAa5F8SDWH2Hlqgky89rGlhG/4DnKqcbRlL+jQ6F0FBP5AQAAAAD9////AhAnAAAAAAAAR1IhApLkOyyLZWwh3QTadFlmp7x3xt+dPgyL/tQ47r+exVRiIQO7Ut/DRj54BKrR0Kf7c42enyfrbV4TDSpsMiqhfrnQm1KuokkAAAAAAAAiACD0hQx+A3+kUAR7iBY5VjkG2DViANmiP0xOBPixU1x36AAAAAAAAQDqAgAAAAABAecL0e2g6vO11ZpVRcHuBDFZNdXUqcDOmYsg7lK86S3cAAAAAAD+////AlpmwwIAAAAAFgAU370BMJPnoYItIaum9dnKt8LCLI8wdQAAAAAAACIAIILP1EkLWcvTQ15pBdk3paMwDIvglbUG6FQBBon3sRAMAkcwRAIgOYjunqLCM9LhnLS9lVoPSVR6z5Phk9BxodHar/ncgGgCIALhH3N/Q1yD7FxE7SSA9sogkcW3WXH1kxy3BLuMcU1zASECoJ99bEErPxgEAT+Nt7GhfwlgQ24fC//v/3LCUQnpzzBkgSEAAQErMHUAAAAAAAAiACCCz9RJC1nL00NeaQXZN6WjMAyL4JW1BuhUAQaJ97EQDAEFR1IhAip4P8CC/dZji38IFOD6ZjW50Pv3RazsvZExGHoy+MupIQPjlUrnEv00n6ytsa4sIMXdSjKHlXn94P4PBuOifenW51KuIgYCKng/wIL91mOLfwgU4PpmNbnQ+/dFrOy9kTEYejL4y6kMsCkMNwAAAAAAAAAAIgYD45VK5xL9NJ+srbGuLCDF3Uoyh5V5/eD+Dwbjon3p1ucMyqFhVgAAAAAAAAAAAAAiAgMacPy3H41FU/Xw+P81xScxWS/jO5Ny1gGnON1fo+4zbQzKoWFWAQAAAAAAAAAiAgOZ2MtgB/5WFgVoNU56XwjdHdTDuO2TYeQNe8TSV2tq7QywKQw3AQAAAAAAAAAA"
 		.encode()).unwrap_or_default()
 }
 
-fn dummy_descriptor()->BoundedVec<u8, OutputDescriptorMaxLen>{
+fn dummy_descriptor() -> BoundedVec<u8, OutputDescriptorMaxLen> {
 	let d_size: usize = OutputDescriptorMaxLen::get().try_into().unwrap();
 	BoundedVec::<u8, OutputDescriptorMaxLen>::try_from(vec![0; d_size]).unwrap()
 }
-fn make_vault_valid(vault_id: [u8;32]){
-
-	Vaults::<Test>::mutate(vault_id, |v_option|{
-		let v= v_option.as_mut().unwrap();
+fn make_vault_valid(vault_id: [u8; 32]) {
+	Vaults::<Test>::mutate(vault_id, |v_option| {
+		let v = v_option.as_mut().unwrap();
 		v.offchain_status.clone_from(&BDKStatus::Valid);
-		v.descriptors.clone_from(&Descriptors{
+		v.descriptors.clone_from(&Descriptors {
 			output_descriptor: dummy_descriptor(),
 			change_descriptor: Some(dummy_descriptor()),
 		});
 	});
 }
 
-fn make_proposal_valid(proposal_id: [u8;32]){
-	Proposals::<Test>::mutate(proposal_id, |p_option|{
+fn make_proposal_valid(proposal_id: [u8; 32]) {
+	Proposals::<Test>::mutate(proposal_id, |p_option| {
 		let p = p_option.as_mut().unwrap();
 		p.offchain_status.clone_from(&BDKStatus::Valid);
 	});
@@ -77,33 +77,40 @@ fn make_proposal_valid(proposal_id: [u8;32]){
 fn set_xpub_identity_works() {
 	new_test_ext().execute_with(|| {
 		// Dispatch a signed extrinsic.
-		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub() ));
-		assert_eq!(BitcoinVaults::xpubs_by_owner(test_pub(1)), Some( dummy_xpub().using_encoded(blake2_256)) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_eq!(
+			BitcoinVaults::xpubs_by_owner(test_pub(1)),
+			Some(dummy_xpub().using_encoded(blake2_256))
+		);
 	});
 }
 
 #[test]
 fn inserting_same_xpub_should_fail() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_noop!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub()),Error::<Test>::XPubAlreadyTaken);
-
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_noop!(
+			BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub()),
+			Error::<Test>::XPubAlreadyTaken
+		);
 	});
 }
 
 #[test]
 fn inserting_without_removing_xpub_should_fail() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_noop!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub_2()),Error::<Test>::UserAlreadyHasXpub);
-
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_noop!(
+			BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub_2()),
+			Error::<Test>::UserAlreadyHasXpub
+		);
 	});
 }
 
 #[test]
 fn removing_xpub_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
 		assert_ok!(BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))));
 	});
 }
@@ -111,433 +118,1105 @@ fn removing_xpub_should_work() {
 #[test]
 fn replacing_xpub_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
 		assert_ok!(BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))));
-		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)),dummy_xpub_2() )  );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub_2()));
 	});
 }
 
 #[test]
 fn removing_twice_should_not_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
 		assert_ok!(BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))));
-		assert_noop!(BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))), Error::<Test>::XPubNotFound);
-
+		assert_noop!(
+			BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))),
+			Error::<Test>::XPubNotFound
+		);
 	});
 }
 
 #[test]
 fn creating_vault_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(),true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
-
-
 	});
 }
-
 
 #[test]
 fn vault_without_cosigners_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
-		default();
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), true,cosigners), Error::<Test>::NotEnoughCosigners );
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
-
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		let cosigners =
+			BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::default(
+			);
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				1,
+				dummy_description(),
+				true,
+				cosigners
+			),
+			Error::<Test>::NotEnoughCosigners
+		);
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 	});
 }
 
 #[test]
 fn vault_with_invalid_threshold_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 			try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 0, dummy_description(), true, cosigners.clone()), Error::<Test>::InvalidVaultThreshold );
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 3, dummy_description(), true, cosigners), Error::<Test>::InvalidVaultThreshold );
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				0,
+				dummy_description(),
+				true,
+				cosigners.clone()
+			),
+			Error::<Test>::InvalidVaultThreshold
+		);
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				3,
+				dummy_description(),
+				true,
+				cosigners
+			),
+			Error::<Test>::InvalidVaultThreshold
+		);
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 	});
 }
 
 #[test]
 fn vault_with_duplicate_members_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 			try_from([ test_pub(2),test_pub(1),].to_vec()).unwrap();
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), true,
-			cosigners.clone()), Error::<Test>::DuplicateVaultMembers );
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				1,
+				dummy_description(),
+				true,
+				cosigners.clone()
+			),
+			Error::<Test>::DuplicateVaultMembers
+		);
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
 	});
 }
 
 #[test]
 fn vault_with_duplicate_incomplete_members() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
 
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 			try_from([ test_pub(2),test_pub(1),].to_vec()).unwrap();
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), true,
-			cosigners.clone()), Error::<Test>::DuplicateVaultMembers );
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				1,
+				dummy_description(),
+				true,
+				cosigners.clone()
+			),
+			Error::<Test>::DuplicateVaultMembers
+		);
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
 	});
 }
 
 #[test]
 fn exceeding_max_cosigners_per_vault_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(3)), dummy_xpub_3()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(4)), dummy_xpub_4()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(3)), dummy_xpub_3()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(4)), dummy_xpub_4()));
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),test_pub(3), test_pub(4)].to_vec()).unwrap();
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(),true, cosigners), Error::<Test>::ExceedMaxCosignersPerVault );
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				2,
+				dummy_description(),
+				true,
+				cosigners
+			),
+			Error::<Test>::ExceedMaxCosignersPerVault
+		);
 		assert!(BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
-
-
 	});
 }
-
 
 #[test]
 fn vault_signer_without_xpub_shouldnt_exist() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 			try_from([ test_pub(2),].to_vec()).unwrap();
-		let cosigners2 = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
-			try_from([ test_pub(1),].to_vec()).unwrap();
+		let cosigners2 = BoundedVec::<
+			<Test as frame_system::Config>::AccountId,
+			MaxCosignersPerVault,
+		>::try_from([test_pub(1)].to_vec())
+		.unwrap();
 		// Case 1: cosigner with no xpub
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), true, cosigners.clone()), Error::<Test>::XPubNotFound );
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				1,
+				dummy_description(),
+				true,
+				cosigners.clone()
+			),
+			Error::<Test>::XPubNotFound
+		);
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
 		// Case 2: owner with no xpub
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(2)) , 1, dummy_description(), true, cosigners2.clone()), Error::<Test>::XPubNotFound );
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
-		assert!( BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(2)),
+				1,
+				dummy_description(),
+				true,
+				cosigners2.clone()
+			),
+			Error::<Test>::XPubNotFound
+		);
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		assert!(BitcoinVaults::vaults_by_signer(test_pub(2)).is_empty());
 	});
 }
 
 #[test]
 fn signer_reached_max_vaults() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(3)), dummy_xpub_3()) );
-		let cosigners1 = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
-			try_from([ test_pub(2),].to_vec()).unwrap();
-		let cosigners2 = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
-			try_from([ test_pub(2), test_pub(3)].to_vec()).unwrap();
-		let cosigners3 = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
-			try_from([ test_pub(3)].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(3)), dummy_xpub_3()));
+		let cosigners1 = BoundedVec::<
+			<Test as frame_system::Config>::AccountId,
+			MaxCosignersPerVault,
+		>::try_from([test_pub(2)].to_vec())
+		.unwrap();
+		let cosigners2 = BoundedVec::<
+			<Test as frame_system::Config>::AccountId,
+			MaxCosignersPerVault,
+		>::try_from([test_pub(2), test_pub(3)].to_vec())
+		.unwrap();
+		let cosigners3 = BoundedVec::<
+			<Test as frame_system::Config>::AccountId,
+			MaxCosignersPerVault,
+		>::try_from([test_pub(3)].to_vec())
+		.unwrap();
 
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners1) );
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 3, dummy_description(), true, cosigners2) );
-		assert_noop!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners3), Error::<Test>::SignerVaultLimit );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners1
+		));
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			3,
+			dummy_description(),
+			true,
+			cosigners2
+		));
+		assert_noop!(
+			BitcoinVaults::create_vault(
+				RuntimeOrigin::signed(test_pub(1)),
+				2,
+				dummy_description(),
+				true,
+				cosigners3
+			),
+			Error::<Test>::SignerVaultLimit
+		);
 
-		assert_eq!( BitcoinVaults::vaults_by_signer(test_pub(1)).len(), 2);
+		assert_eq!(BitcoinVaults::vaults_by_signer(test_pub(1)).len(), 2);
 	});
 }
 
 #[test]
 fn removing_vault_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(3)), dummy_xpub_3()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(3)), dummy_xpub_3()));
 
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),test_pub(3)].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), false, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			1,
+			dummy_description(),
+			false,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		// Try to remove xpub (vault depends on it)
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
-		assert_ok!(BitcoinVaults::remove_vault(RuntimeOrigin::signed(test_pub(1)),vault_id));
-
+		assert_ok!(BitcoinVaults::remove_vault(RuntimeOrigin::signed(test_pub(1)), vault_id));
 	});
 }
 
 #[test]
 fn removing_vault_which_isnt_yours_shoulnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		// Try to remove xpub (vault depends on it)
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
-		assert_noop!(BitcoinVaults::remove_vault(RuntimeOrigin::signed(test_pub(2)),vault_id),  Error::<Test>::VaultOwnerPermissionsNeeded);
-
+		assert_noop!(
+			BitcoinVaults::remove_vault(RuntimeOrigin::signed(test_pub(2)), vault_id),
+			Error::<Test>::VaultOwnerPermissionsNeeded
+		);
 	});
 }
 
 #[test]
 fn removing_vault_and_xpub_in_order_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		// TODO: Remove vault
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
-		assert_ok!(BitcoinVaults::remove_vault(RuntimeOrigin::signed(test_pub(1)),vault_id));
+		assert_ok!(BitcoinVaults::remove_vault(RuntimeOrigin::signed(test_pub(1)), vault_id));
 		// Try to remove xpub (vault depends on it)
 		assert_ok!(BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))));
-
 	});
 }
 
 #[test]
 fn removing_xpub_before_vault_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		// Try to remove xpub (vault depends on it)
-		assert_noop!(BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))), Error::<Test>::XpubLinkedToVault);
-
+		assert_noop!(
+			BitcoinVaults::remove_xpub(RuntimeOrigin::signed(test_pub(1))),
+			Error::<Test>::XpubLinkedToVault
+		);
 	});
 }
 
 #[test]
-fn proposing_should_work(){
+fn proposing_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
 	});
 }
 
 #[test]
-fn proposing_from_external_user_should_work(){
+fn proposing_from_external_user_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		// user 3 is not on the vault so it should expect an error
-		assert_noop!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(3)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()),
-			Error::<Test>::SignerPermissionsNeeded);
+		assert_noop!(
+			BitcoinVaults::propose(
+				RuntimeOrigin::signed(test_pub(3)),
+				vault_id,
+				dummy_testnet_recipient_address(),
+				1000,
+				dummy_description()
+			),
+			Error::<Test>::SignerPermissionsNeeded
+		);
 	});
 }
 
 #[test]
-fn proposing_twice_shouldnt_work(){
+fn proposing_twice_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
-		assert_noop!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()),
-			Error::<Test>::AlreadyProposed);
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
+		assert_noop!(
+			BitcoinVaults::propose(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_testnet_recipient_address(),
+				1000,
+				dummy_description()
+			),
+			Error::<Test>::AlreadyProposed
+		);
 	});
 }
 
 #[test]
-fn exceeding_max_proposals_per_vault_shouldnt_work(){
+fn exceeding_max_proposals_per_vault_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1001,dummy_description()));
-		assert_noop!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1002,dummy_description()),
-			Error::<Test>::ExceedMaxProposalsPerVault);
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1001,
+			dummy_description()
+		));
+		assert_noop!(
+			BitcoinVaults::propose(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_testnet_recipient_address(),
+				1002,
+				dummy_description()
+			),
+			Error::<Test>::ExceedMaxProposalsPerVault
+		);
 	});
 }
 
 #[test]
-fn saving_psbt_should_work(){
+fn saving_psbt_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
 		// obtaining proposal id and saving a psbt
 		let proposal_id = BitcoinVaults::proposals_by_vault(vault_id).pop().unwrap();
-		assert_ok!(BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()));
+		assert_ok!(BitcoinVaults::save_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			proposal_id,
+			dummy_psbt()
+		));
 	});
 }
 
 #[test]
-fn saving_psbt_to_a_nonexistent_proposal_shouldnt_work(){
+fn saving_psbt_to_a_nonexistent_proposal_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		// user 3 is not on the vault so it should expect an error
-		let proposal_id = [0;32];
-		assert_noop!(BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()), Error::<Test>::ProposalNotFound);
+		let proposal_id = [0; 32];
+		assert_noop!(
+			BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()),
+			Error::<Test>::ProposalNotFound
+		);
 	});
 }
 
 #[test]
-fn saving_psbt_form_external_user_shouldnt_work(){
+fn saving_psbt_form_external_user_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
 		// obtaining proposal id and saving a psbt with a user that is not in the vault
 		let proposal_id = BitcoinVaults::proposals_by_vault(vault_id).pop().unwrap();
 		// user 3 is not on
-		assert_noop!(BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(3)), proposal_id, dummy_psbt()), Error::<Test>::SignerPermissionsNeeded);
+		assert_noop!(
+			BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(3)), proposal_id, dummy_psbt()),
+			Error::<Test>::SignerPermissionsNeeded
+		);
 	});
 }
 
 #[test]
-fn saving_twice_psbt_shouldnt_work(){
+fn saving_twice_psbt_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 2, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
 		// obtaining proposal id and saving a psbt with a user that is not in the vault
 		let proposal_id = BitcoinVaults::proposals_by_vault(vault_id).pop().unwrap();
 		// user 3 is not on the vaults cosigners
-		assert_ok!(BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()) );
-		assert_noop!(BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()), Error::<Test>::AlreadySigned);
+		assert_ok!(BitcoinVaults::save_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			proposal_id,
+			dummy_psbt()
+		));
+		assert_noop!(
+			BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()),
+			Error::<Test>::AlreadySigned
+		);
 	});
 }
 
 // TODO: Set offchainStatus proposal from pending to Valid
 #[test]
-fn finalize_psbt_should_work(){
+fn finalize_psbt_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			1,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
 		// obtaining proposal id and saving a psbt with a user that is not in the vault
 		let proposal_id = BitcoinVaults::proposals_by_vault(vault_id).pop().unwrap();
 		make_proposal_valid(proposal_id);
 
-		assert_ok!(BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()));
+		assert_ok!(BitcoinVaults::save_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			proposal_id,
+			dummy_psbt()
+		));
 		// When a proposal meets the threshold changes it status to ReadyToFinalize false
-		assert!(BitcoinVaults::proposals(proposal_id).unwrap().status.eq(&ProposalStatus::ReadyToFinalize(false)));
+		assert!(BitcoinVaults::proposals(proposal_id)
+			.unwrap()
+			.status
+			.eq(&ProposalStatus::ReadyToFinalize(false)));
 	});
 }
 
 #[test]
-fn finalize_psbt_twice_shouldnt_work(){
+fn finalize_psbt_twice_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			1,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
 		// obtaining proposal id and saving a psbt with a user that is not in the vault
 		let proposal_id = BitcoinVaults::proposals_by_vault(vault_id).pop().unwrap();
 		make_proposal_valid(proposal_id);
 
-		assert_ok!(BitcoinVaults::save_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, dummy_psbt()) );
+		assert_ok!(BitcoinVaults::save_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			proposal_id,
+			dummy_psbt()
+		));
 		// When a proposal meets the threshold changes it status to ReadyToFinalize false
-		assert!(BitcoinVaults::proposals(proposal_id).unwrap().status.eq(&ProposalStatus::ReadyToFinalize(false)));
-		assert_noop!(BitcoinVaults::finalize_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id,false), Error::<Test>::PendingProposalRequired);
+		assert!(BitcoinVaults::proposals(proposal_id)
+			.unwrap()
+			.status
+			.eq(&ProposalStatus::ReadyToFinalize(false)));
+		assert_noop!(
+			BitcoinVaults::finalize_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, false),
+			Error::<Test>::PendingProposalRequired
+		);
 	});
 }
 
 #[test]
-fn finalize_psbt_without_signatures_shouldnt_work(){
+fn finalize_psbt_without_signatures_shouldnt_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()) );
-		assert_ok!( BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()) );
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
 		// Insert a normal vault
 		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
 		try_from([ test_pub(2),].to_vec()).unwrap();
-		assert_ok!(BitcoinVaults::create_vault( RuntimeOrigin::signed(test_pub(1)) , 1, dummy_description(), true, cosigners) );
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			1,
+			dummy_description(),
+			true,
+			cosigners
+		));
 		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
 		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
 		make_vault_valid(vault_id);
-		assert_ok!(BitcoinVaults::propose(RuntimeOrigin::signed(test_pub(1)),vault_id,dummy_testnet_recipient_address(),1000,dummy_description()));
+		assert_ok!(BitcoinVaults::propose(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_testnet_recipient_address(),
+			1000,
+			dummy_description()
+		));
 		// obtaining proposal id and saving a psbt with a user that is not in the vault
 		let proposal_id = BitcoinVaults::proposals_by_vault(vault_id).pop().unwrap();
 		make_proposal_valid(proposal_id);
 
-		assert_noop!(BitcoinVaults::finalize_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id,false), Error::<Test>::NotEnoughSignatures);
+		assert_noop!(
+			BitcoinVaults::finalize_psbt(RuntimeOrigin::signed(test_pub(1)), proposal_id, false),
+			Error::<Test>::NotEnoughSignatures
+		);
+	});
+}
+
+#[test]
+fn proof_of_reserve_should_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		make_vault_valid(vault_id);
+		// user 3 is not on the vault so it should expect an error
+		assert_ok!(BitcoinVaults::create_proof(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_description(),
+			dummy_psbt()
+		));
+	});
+}
+
+#[test]
+fn proof_of_reserve_from_external_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		make_vault_valid(vault_id);
+		// user 3 is not on the vault so it should expect an error
+		assert_noop!(
+			BitcoinVaults::create_proof(
+				RuntimeOrigin::signed(test_pub(3)),
+				vault_id,
+				dummy_description(),
+				dummy_psbt()
+			),
+			Error::<Test>::SignerPermissionsNeeded
+		);
+	});
+}
+#[test]
+fn proof_of_reserve_from_nonexistent_vault_should_not_work() {
+	new_test_ext().execute_with(|| {
+		let vault_id = [0; 32];
+		// user 3 is not on the vault so it should expect an error
+		assert_noop!(
+			BitcoinVaults::create_proof(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_description(),
+				dummy_psbt()
+			),
+			Error::<Test>::VaultNotFound
+		);
+	});
+}
+
+#[test]
+fn proof_of_reserve_from_invalid_vault_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		// user 3 is not on the vault so it should expect an error
+		assert_noop!(
+			BitcoinVaults::create_proof(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_description(),
+				dummy_psbt()
+			),
+			Error::<Test>::InvalidVault
+		);
+	});
+}
+
+#[test]
+fn save_proof_psbt_should_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		make_vault_valid(vault_id);
+		// user 3 is not on the vault so it should expect an error
+		assert_ok!(BitcoinVaults::create_proof(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_description(),
+			dummy_psbt()
+		));
+
+		assert_ok!(BitcoinVaults::save_proof_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_psbt(),
+			false
+		));
+	});
+}
+
+#[test]
+fn save_nonexistent_proof_psbt_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		make_vault_valid(vault_id);
+
+		assert_noop!(
+			BitcoinVaults::save_proof_psbt(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_psbt(),
+				false
+			),
+			Error::<Test>::ProofNotFound
+		);
+	});
+}
+
+#[test]
+fn save_proof_psbt_invalid_vault_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		// Invalid vault error should appear first than ProofNotFound
+		assert_noop!(
+			BitcoinVaults::save_proof_psbt(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_psbt(),
+				false
+			),
+			Error::<Test>::InvalidVault
+		);
+	});
+}
+
+#[test]
+fn save_proof_psbt_nonexistent_vault_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+
+		let vault_id = [0; 32];
+		// Invalid vault error should appear first than ProofNotFound
+		assert_noop!(
+			BitcoinVaults::save_proof_psbt(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_psbt(),
+				false
+			),
+			Error::<Test>::VaultNotFound
+		);
+	});
+}
+
+#[test]
+fn save_twice_proof_psbt_should_not_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		make_vault_valid(vault_id);
+		assert_ok!(BitcoinVaults::create_proof(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_description(),
+			dummy_psbt()
+		));
+
+		assert_ok!(BitcoinVaults::save_proof_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_psbt(),
+			false
+		));
+
+		assert_noop!(
+			BitcoinVaults::save_proof_psbt(
+				RuntimeOrigin::signed(test_pub(1)),
+				vault_id,
+				dummy_psbt(),
+				false
+			),
+			Error::<Test>::AlreadySigned
+		);
+	});
+}
+
+#[test]
+fn ready_to_finalize_proof_psbt_should_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		make_vault_valid(vault_id);
+
+		assert_ok!(BitcoinVaults::create_proof(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_description(),
+			dummy_psbt()
+		));
+
+		assert_ok!(BitcoinVaults::save_proof_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_psbt(),
+			false
+		));
+
+		assert_ok!(BitcoinVaults::save_proof_psbt(
+			RuntimeOrigin::signed(test_pub(2)),
+			vault_id,
+			dummy_psbt(),
+			false
+		));
+		assert!(ProofOfReserves::<Test>::get(vault_id).unwrap().status.is_ready_to_finalize())
+	});
+}
+
+#[test]
+fn finalize_proof_psbt_should_work() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(1)), dummy_xpub()));
+		assert_ok!(BitcoinVaults::set_xpub(RuntimeOrigin::signed(test_pub(2)), dummy_xpub_2()));
+		// Insert a normal vault
+		let cosigners = BoundedVec::<<Test as frame_system::Config>::AccountId, MaxCosignersPerVault>::
+		try_from([ test_pub(2),].to_vec()).unwrap();
+		assert_ok!(BitcoinVaults::create_vault(
+			RuntimeOrigin::signed(test_pub(1)),
+			2,
+			dummy_description(),
+			true,
+			cosigners
+		));
+		assert!(!BitcoinVaults::vaults_by_signer(test_pub(1)).is_empty());
+		let vault_id = BitcoinVaults::vaults_by_signer(test_pub(1)).pop().unwrap();
+		make_vault_valid(vault_id);
+
+		assert_ok!(BitcoinVaults::create_proof(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_description(),
+			dummy_psbt()
+		));
+
+		assert_ok!(BitcoinVaults::save_proof_psbt(
+			RuntimeOrigin::signed(test_pub(1)),
+			vault_id,
+			dummy_psbt(),
+			false
+		));
+
+		assert_ok!(BitcoinVaults::save_proof_psbt(
+			RuntimeOrigin::signed(test_pub(2)),
+			vault_id,
+			dummy_psbt(),
+			true
+		));
+		assert_eq!(
+			ProofOfReserves::<Test>::get(vault_id).unwrap().status,
+			ProposalStatus::Finalized
+		)
 	});
 }

--- a/pallets/bitcoin-vaults/src/types.rs
+++ b/pallets/bitcoin-vaults/src/types.rs
@@ -4,6 +4,9 @@ use frame_support::pallet_prelude::*;
 use frame_support::sp_io::hashing::blake2_256;
 use sp_runtime::{sp_std::vec::Vec};
 use frame_system::offchain::{SigningTypes, SignedPayload};
+
+pub type Description<T> = BoundedVec<u8, <T as Config>::VaultDescriptionMaxLen>;
+pub type PSBT<T> = BoundedVec<u8, <T as Config>::PSBTMaxLen>;
 //pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 /*--- Constants section ---*/
 //pub const BDK_SERVICES_URL: &[u8] = b"https://bdk.hashed.systems";
@@ -165,6 +168,19 @@ impl<T: Config> Clone for Proposal<T>{
 		}
 	}
 }
+
+
+// Struct for holding Proof of reserve information.
+#[derive(CloneNoBound, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+#[codec(mel_bound())]
+pub struct ProofOfReserve<T: Config> {
+	pub status: ProposalStatus,
+	pub message: Description<T>,
+	pub psbt: PSBT<T>,
+	pub signed_psbts: BoundedVec<ProposalSignatures<T>, T::MaxCosignersPerVault>,
+}
+
 
 #[derive(
 	Encode,


### PR DESCRIPTION
## Overview

Enables new data flow for the Proof of Reserve functionality

## Implementation notes

- New data struct `ProofOfReserve`
- New storage map `ProofOfReserves`
- New txs: `create_proof` & `save_proof_psbt`. `do_remove_proof` was only used on vault removal and it was not exposed as an extrinsic.


## Test coverage

11 unit tests added.

## Loose ends

Several optimizations are yet to be performed on the whole pallet.
